### PR TITLE
Add base viewmodel

### DIFF
--- a/Source/Resizer.Gui/Helpers/ViewModel/ViewModelBase.cs
+++ b/Source/Resizer.Gui/Helpers/ViewModel/ViewModelBase.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace Resizer.Gui.Helpers.ViewModel
+{
+    /// <summary>
+    /// Base viewmodel that implements <see cref="INotifyPropertyChanged"/> to simplify viewmodels
+    /// </summary>
+    public abstract class ViewModelBase : INotifyPropertyChanged
+    {
+        /// <summary>
+        /// Occures when a property value changes
+        /// </summary>
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        /// <summary>
+        /// Raises the property changed event
+        /// </summary>
+        /// <param name="args"><see cref="PropertyChangedEventArgs"/></param>
+        protected virtual void OnPropertyChanged(PropertyChangedEventArgs args)
+        {
+            PropertyChanged?.Invoke(this, args);
+        }
+
+        /// <summary>
+        /// Sets a property and notifies it's listeners
+        /// NOTE: only sets and notifies if the value doesnt match the desired value
+        /// </summary>
+        /// <typeparam name="T">Type of the property</typeparam>
+        /// <param name="storage">Reference to a property with getter and setter</param>
+        /// <param name="value">Desired value for the property</param>
+        /// <param name="propertyName">Name of the property used to notify listeners</param>
+        /// <returns>Returns <see langword="true"/> if the value was changed, otherwise <see langword="false"/></returns>
+        protected virtual bool SetProperty<T>(ref T storage, T value, [CallerMemberName] string? propertyName = null)
+        {
+            if(EqualityComparer<T>.Default.Equals(storage, value))
+            {
+                return false;
+            }
+
+            storage = value;
+            RaisePropertyChanged(propertyName);
+
+            return true;
+        }
+
+        /// <summary>
+        /// Sets a property and notifies it's listeners
+        /// NOTE: only sets and notifies if the value doesnt match the desired value
+        /// </summary>
+        /// <typeparam name="T">Type of the property</typeparam>
+        /// <param name="storage">Reference to a property with getter and setter</param>
+        /// <param name="value">Desired value for the property</param>
+        /// <param name="onChanged">Action to be called after the property value has changed</param>
+        /// <param name="propertyName">Name of the property used to notify listeners</param>
+        /// <returns>Returns <see langword="true"/> if the value was changed, otherwise <see langword="false"/></returns>
+        protected virtual bool SetProperty<T>(ref T storage, T value, Action onChanged, [CallerMemberName] string? propertyName = null)
+        {
+            if (EqualityComparer<T>.Default.Equals(storage, value))
+            {
+                return false;
+            }
+
+            storage = value;
+            onChanged?.Invoke();
+            RaisePropertyChanged(propertyName);
+
+            return true;
+        }
+
+        /// <summary>
+        /// Raises the PropertyChanged event
+        /// </summary>
+        /// <param name="propertyName">Name of the property to notify the listeners of</param>
+        protected void RaisePropertyChanged([CallerMemberName] string? propertyName = null)
+        {
+            OnPropertyChanged(new PropertyChangedEventArgs(propertyName));
+        }
+
+    }
+}

--- a/Source/Tests/Resizer.Gui.Tests/Helpers/ViewModel/ViewModelBaseTests.cs
+++ b/Source/Tests/Resizer.Gui.Tests/Helpers/ViewModel/ViewModelBaseTests.cs
@@ -1,0 +1,122 @@
+﻿using Resizer.Gui.Helpers.ViewModel;
+using Xunit;
+
+namespace Resizer.Gui.Tests.Helpers.ViewModel
+{
+    /// <summary>
+    /// Tests for the <see cref="ViewModelBase"/>
+    /// </summary>
+    public class ViewModelBaseTests
+    {
+        private class MockViewModel : ViewModelBase
+        {
+            private int _mockProperty;
+
+            public int MockProperty
+            {
+                get => _mockProperty;
+                set => SetProperty(ref _mockProperty, value);
+            }
+
+            internal void InvokeOnPropertyChanged()
+            {
+                RaisePropertyChanged(nameof(MockProperty));
+            }
+        }
+
+        #region SetProperty Tests
+
+        [Fact]
+        public void SetProperty_NewValue_ShouldSetValue()
+        {
+            // Prepare
+            int value = 10;
+            var mockViewModel = new MockViewModel();
+
+            // Assert
+            Assert.Equal(0, mockViewModel.MockProperty);
+
+            // Act
+            mockViewModel.MockProperty = value;
+
+            // Assert
+            Assert.Equal(value, mockViewModel.MockProperty);
+        }
+
+        [Fact]
+        public void SetProperty_UnchangedValue_ShouldNotSet()
+        {
+            // Prepare
+            var oldValue = 10;
+            var newValue = 10;
+            var mockViewModel = new MockViewModel {MockProperty = oldValue};
+            var invoked = false;
+            mockViewModel.PropertyChanged += (o, e) =>
+            {
+                // Act
+                if (e.PropertyName.Equals(nameof(mockViewModel.MockProperty)))
+                {
+                    invoked = true;
+                }
+            };
+
+            // Act
+            mockViewModel.MockProperty = newValue;
+
+            // Assert
+            Assert.False(invoked);
+            Assert.Equal(oldValue, mockViewModel.MockProperty);
+        }
+
+        [Fact]
+        public void SetProperty_NewValue_ShouldRaisePropertyChanged()
+        {
+            // Prepare
+            var value = 10;
+            var mockViewModel = new MockViewModel();
+            var invoked = false;
+            mockViewModel.PropertyChanged += (o, e) =>
+            {
+                // Act
+                if (e.PropertyName.Equals(nameof(mockViewModel.MockProperty)))
+                {
+                    invoked = true;
+                }
+            };
+
+            // Act
+            mockViewModel.MockProperty = value;
+
+            // Assert
+            Assert.True(invoked);
+        }
+
+        #endregion
+
+        #region OnPropertyChanged Tests
+
+        [Fact]
+        public void OnPropertyChanged_Raised_ShouldExtractPropertyName()
+        {
+            // Prepare
+            var invoked = false;
+            var mockViewModel = new MockViewModel();
+            mockViewModel.PropertyChanged += (o, e) =>
+            {
+                // Act
+                if (e.PropertyName.Equals(nameof(mockViewModel.MockProperty)))
+                {
+                    invoked = true;
+                }
+            };
+
+            // Act
+            mockViewModel.InvokeOnPropertyChanged();
+
+            //Assert
+            Assert.True(invoked);
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
## What does the pull request do?
Adds a base viewmodel for viewmodels to use


## What is the current behavior?
Currently each viewmodel needs to boiletplate the INotifyPropertyChanged


## What is the updated/expected behavior with this PR?
The ViewModelBase can be implemented to provide a INotifyPropertyChanged implementation


## How was the solution implemented (if it's not obvious)?
n/a


## Checklist

- [x ] Added unit tests (if possible)?
- [ x] Added XML documentation to any related classes?

## Breaking changes
n/a


## Fixed issues
n/a
