### PR TITLE
Add null forgiving operators to delegate reference tests

### DIFF
--- a/Source/Tests/Resizer.Gui.Tests/Helpers/Command/DelegateCommandTests.cs
+++ b/Source/Tests/Resizer.Gui.Tests/Helpers/Command/DelegateCommandTests.cs
@@ -46,7 +46,7 @@ namespace Resizer.Gui.Tests.Helpers.Command
             // Assert
             Assert.Throws<ArgumentNullException>(() =>
             {
-                var actual = new DelegateCommand(null, null);
+                var actual = new DelegateCommand(null!, null);
             });
         }
 
@@ -60,7 +60,7 @@ namespace Resizer.Gui.Tests.Helpers.Command
             // Assert
             Assert.Throws<ArgumentNullException>(() =>
             {
-                var actual = new DelegateCommand(null);
+                var actual = new DelegateCommand(null!);
             });
         }
 
@@ -112,7 +112,7 @@ namespace Resizer.Gui.Tests.Helpers.Command
             // Assert
             Assert.Throws<ArgumentNullException>(() =>
             {
-                var actual = new DelegateCommand<object>(null, null);
+                var actual = new DelegateCommand<object>(null!, null);
             });
         }
 
@@ -126,7 +126,7 @@ namespace Resizer.Gui.Tests.Helpers.Command
             // Assert
             Assert.Throws<ArgumentNullException>(() =>
             {
-                var actual = new DelegateCommand<object>(null);
+                var actual = new DelegateCommand<object>(null!);
             });
         }
 
@@ -244,7 +244,7 @@ namespace Resizer.Gui.Tests.Helpers.Command
             var command = new DelegateCommand<object>(handler.Execute);
 
             // Act
-            var returnValue = command.CanExecute(null);
+            var returnValue = command.CanExecute(null!);
 
             // Assert
             Assert.True(returnValue);


### PR DESCRIPTION
## What does the pull request do?
Adds null forgiving operators to all the null tests in the delegate reference tests


## What is the current behavior?
Currently the project throws several warnings about converting null literal to non-nullable reference types


## What is the updated/expected behavior with this PR?
During tests cases null should be allowed to be set, and shouldnt riddle the console with warnings


## How was the solution implemented (if it's not obvious)?
With the null forgiving operator we express that x of a given reference type isn't null


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?

## Breaking changes
n/a


## Fixed issues
n/a