### PR TITLE
Remove workflow execution on push

### DIFF
--- a/.github/workflows/project-validation.yml
+++ b/.github/workflows/project-validation.yml
@@ -1,7 +1,6 @@
 name: 'Test and Build'
 
 on:
-  push:
   pull_request:
 
 # Defines environment variables


### PR DESCRIPTION
## What does the pull request do?
Removes the execution of the project-validation on every push as this does not seem fully necessary


## What is the current behavior?
Currently the project validation workflow is executed everytime a push is done, execution time on windows seems rather slow compaired to ubuntu which means it slows stuff down. besides that not every push persé requires a valid build or tests, and thus the removal of execution on push seems warrented


## What is the updated/expected behavior with this PR?
The project validation executes only once during a pull request, and no longer during push


## How was the solution implemented (if it's not obvious)?
on push got removed from the workflow 


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?

## Breaking changes
n/a


## Fixed issues
n/a
