### PR TITLE
Fix viewmodel injection

### DIFF
--- a/Source/Resizer.Gui/ActiveWindows/ActiveWindowsView.xaml
+++ b/Source/Resizer.Gui/ActiveWindows/ActiveWindowsView.xaml
@@ -5,9 +5,11 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
              xmlns:converters="clr-namespace:Resizer.Gui.Infrastructure.Converters"
+             xmlns:viewModel="clr-namespace:Resizer.Gui.Infrastructure.Common.ViewModel"
              xmlns:local="clr-namespace:Resizer.Gui.ActiveWindows"
              mc:Ignorable="d"
              d:DataContext="{d:DesignInstance local:ActiveWindowsDesignModel, IsDesignTimeCreatable=True}"
+             viewModel:ViewModelLocator.WireViewModel="{x:Type local:ActiveWindowsViewModel}"
              d:DesignHeight="400"
              d:DesignWidth="400">
     <Grid>

--- a/Source/Resizer.Gui/App.xaml.cs
+++ b/Source/Resizer.Gui/App.xaml.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Windows;
 using Autofac;
-using Autofac.Core;
 using Resizer.Gui.Infrastructure.Common.ViewModel;
-using Resizer.Gui.Window;
 
 namespace Resizer.Gui
 {

--- a/Source/Resizer.Gui/App.xaml.cs
+++ b/Source/Resizer.Gui/App.xaml.cs
@@ -31,23 +31,11 @@ namespace Resizer.Gui
             _container = builder.Build();
 
             // Setup the viewmodel locator
-            ViewModelLocator.SetViewModelFactory((type) =>
-            {
-                if(!type.IsAssignableTo<ViewModelBase>())
-                {
-                    throw new InvalidOperationException("The type provided to the ViewModel factory resolver can not be cast to ViewModelBase");
-                }
-
-                return _container.ResolveKeyed<ViewModelBase>(type);
-                //return _container.Resolve(type) as ViewModelBase;
-            });
+            using var scope = _container.BeginLifetimeScope();
+            ViewModelLocator.SetViewModelFactory(scope.Resolve<Func<Type, ViewModelBase>>());
 
             // Setup the main window
-            using var scope = _container.BeginLifetimeScope();
             var window = new MainWindow();
-            //{
-            //    DataContext = scope.Resolve(typeof(WindowViewModel))
-            //};
             window.Show();
         }
 

--- a/Source/Resizer.Gui/DependencyModule.cs
+++ b/Source/Resizer.Gui/DependencyModule.cs
@@ -1,8 +1,11 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Linq;
+using System.Reflection;
 using Autofac;
 using Resizer.Domain.Infrastructure.Messenger;
 using Resizer.Domain.Settings;
 using Resizer.Domain.Windows;
+using Resizer.Gui.Infrastructure.Common.ViewModel;
 
 namespace Resizer.Gui
 {
@@ -49,7 +52,21 @@ namespace Resizer.Gui
         private ContainerBuilder RegisterGuiDependencies(ContainerBuilder builder)
         {
             // Viewmodels
-            builder.RegisterAssemblyTypes(Assembly.GetExecutingAssembly()).Where(t => t.Name.EndsWith("ViewModel")).AsImplementedInterfaces().InstancePerDependency();
+            var viewModels = Assembly.GetExecutingAssembly().GetTypes().Where(t => t.IsClass && t.Name.EndsWith("ViewModel"));
+            foreach(var viewmodel in viewModels)
+            {
+                builder.RegisterType(viewmodel).Keyed<ViewModelBase>(viewmodel).InstancePerDependency();
+            }
+
+            //builder.Register<Func<Type, ViewModelBase>>(c =>
+            //{
+            //    var context = c.Resolve<IComponentContext>();
+            //    return (type) => context.ResolveKeyed<ViewModelBase>(type);
+            //});
+
+            //builder.RegisterAssemblyTypes(Assembly.GetExecutingAssembly()).Where(t => t.Name.EndsWith("ViewModel")).Keyed<ViewModelBase>(typeof()).InstancePerDependency();
+
+            //builder.RegisterAssemblyTypes(Assembly.GetExecutingAssembly()).Where(t => t.Name.EndsWith("ViewModel")).AsImplementedInterfaces().InstancePerDependency();
 
             return builder;
         }

--- a/Source/Resizer.Gui/DependencyModule.cs
+++ b/Source/Resizer.Gui/DependencyModule.cs
@@ -53,7 +53,7 @@ namespace Resizer.Gui
         {
             // Viewmodels
             var viewModels = Assembly.GetExecutingAssembly().GetTypes().Where(t => t.IsClass && t.Name.EndsWith("ViewModel"));
-            foreach(var viewmodel in viewModels)
+            foreach (var viewmodel in viewModels)
             {
                 builder.RegisterType(viewmodel).Keyed<ViewModelBase>(viewmodel).InstancePerDependency();
             }

--- a/Source/Resizer.Gui/DependencyModule.cs
+++ b/Source/Resizer.Gui/DependencyModule.cs
@@ -58,15 +58,11 @@ namespace Resizer.Gui
                 builder.RegisterType(viewmodel).Keyed<ViewModelBase>(viewmodel).InstancePerDependency();
             }
 
-            //builder.Register<Func<Type, ViewModelBase>>(c =>
-            //{
-            //    var context = c.Resolve<IComponentContext>();
-            //    return (type) => context.ResolveKeyed<ViewModelBase>(type);
-            //});
-
-            //builder.RegisterAssemblyTypes(Assembly.GetExecutingAssembly()).Where(t => t.Name.EndsWith("ViewModel")).Keyed<ViewModelBase>(typeof()).InstancePerDependency();
-
-            //builder.RegisterAssemblyTypes(Assembly.GetExecutingAssembly()).Where(t => t.Name.EndsWith("ViewModel")).AsImplementedInterfaces().InstancePerDependency();
+            builder.Register<Func<Type, ViewModelBase>>(c =>
+            {
+                var context = c.Resolve<IComponentContext>();
+                return (type) => context.ResolveKeyed<ViewModelBase>(type);
+            });
 
             return builder;
         }

--- a/Source/Resizer.Gui/Infrastructure/Common/ViewModel/ViewModelLocator.cs
+++ b/Source/Resizer.Gui/Infrastructure/Common/ViewModel/ViewModelLocator.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Net;
+using System.Text;
+using System.Windows;
+using Autofac.Features.Indexed;
+
+namespace Resizer.Gui.Infrastructure.Common.ViewModel
+{
+    public static class ViewModelLocator
+    {
+        /// <summary>
+        /// <see cref="Func{T, TResult}"/> used instance a viewmodel
+        /// </summary>
+        private static Func<Type, ViewModelBase>? s_viewmodelFactory;
+
+        /// <summary>
+        /// Sets the viewmodel factory used to instance viewmodels
+        /// </summary>
+        /// <param name="factory"><see cref="Func{T, TResult}"/> used to instance new <see cref="ViewModelBase"/> objects</param>
+        public static void SetViewModelFactory(Func<Type, ViewModelBase> factory)
+        {
+            s_viewmodelFactory = factory ?? throw new ArgumentNullException(nameof(factory));
+        }
+
+        /// <summary>
+        /// The Wire ViewModel attached property
+        /// </summary>
+        public static DependencyProperty WireViewModelProperty = DependencyProperty.RegisterAttached("WireViewModel", typeof(Type), typeof(ViewModelLocator),
+            new PropertyMetadata(defaultValue: null, propertyChangedCallback: WireViewModelChanged));
+
+        /// <summary>
+        /// Gets the <see cref="WireViewModelProperty"/> attached proprty value
+        /// </summary>
+        /// <param name="obj">The target element to set the attached property of</param>
+        /// <returns>Returns <see cref="Type"/> of the currently set attached property value</returns>
+        public static Type GetWireViewModel(DependencyObject obj)
+        {
+            return (Type)obj.GetValue(WireViewModelProperty);
+        }
+
+        /// <summary>
+        /// Sets the <see cref="WireViewModelProperty"/> attached property value
+        /// </summary>
+        /// <param name="obj">The target element to set the attached property of</param>
+        /// <param name="value">The attached property value to be set</param>
+        public static void SetWireViewModel(DependencyObject obj, Type value)
+        {
+            obj.SetValue(WireViewModelProperty, value);
+        }
+        
+        /// <summary>
+        /// Raised when <see cref="WireViewModelProperty"/> changed and attempts to set the datacontext
+        /// </summary>
+        /// <param name="d"></param>
+        /// <param name="e"></param>
+        private static void WireViewModelChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if(!DesignerProperties.GetIsInDesignMode(d))
+            {
+                if((Type)e.NewValue != (Type)e.OldValue)
+                {
+                    if(s_viewmodelFactory == null)
+                    {
+                        throw new NullReferenceException("The ViewModelLocator did not have it's factory method set");
+                    }
+
+                    var viewmodel = s_viewmodelFactory(GetWireViewModel(d));
+                    Bind(d, viewmodel);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Sets the DataContext of a view
+        /// </summary>
+        /// <param name="view">The view to set the DataContext of</param>
+        /// <param name="viewModel">The object to be set as the DataContext</param>
+        private static void Bind(object view, object viewModel)
+        {
+            if(view is FrameworkElement element)
+            {
+                element.DataContext = viewModel;
+            }
+        }
+
+        /// <summary>
+        /// Provides an easy lookup of all indexes
+        /// </summary>
+        ///private static IIndex<Type, ViewModelBase> _lookup;
+
+        /// <summary>
+        /// Sets the <see cref="IIndex{Type, ViewModelBase}"/> used for viewmodel lookup
+        /// </summary>
+        /// <param name="lookup"><see cref="IIndex{Type, ViewModelBase}"/> of all viewmodels</param>
+        //public static void SetLookup(IIndex<Type, ViewModelBase> lookup)
+        //{
+        //    _lookup = lookup;
+        //}
+    }
+}

--- a/Source/Resizer.Gui/Infrastructure/Common/ViewModel/ViewModelLocator.cs
+++ b/Source/Resizer.Gui/Infrastructure/Common/ViewModel/ViewModelLocator.cs
@@ -80,19 +80,5 @@ namespace Resizer.Gui.Infrastructure.Common.ViewModel
                 element.DataContext = viewModel;
             }
         }
-
-        /// <summary>
-        /// Provides an easy lookup of all indexes
-        /// </summary>
-        ///private static IIndex<Type, ViewModelBase> _lookup;
-
-        /// <summary>
-        /// Sets the <see cref="IIndex{Type, ViewModelBase}"/> used for viewmodel lookup
-        /// </summary>
-        /// <param name="lookup"><see cref="IIndex{Type, ViewModelBase}"/> of all viewmodels</param>
-        //public static void SetLookup(IIndex<Type, ViewModelBase> lookup)
-        //{
-        //    _lookup = lookup;
-        //}
     }
 }

--- a/Source/Resizer.Gui/Infrastructure/Common/ViewModel/ViewModelLocator.cs
+++ b/Source/Resizer.Gui/Infrastructure/Common/ViewModel/ViewModelLocator.cs
@@ -1,10 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Net;
-using System.Text;
 using System.Windows;
-using Autofac.Features.Indexed;
 
 namespace Resizer.Gui.Infrastructure.Common.ViewModel
 {
@@ -49,7 +45,7 @@ namespace Resizer.Gui.Infrastructure.Common.ViewModel
         {
             obj.SetValue(WireViewModelProperty, value);
         }
-        
+
         /// <summary>
         /// Raised when <see cref="WireViewModelProperty"/> changed and attempts to set the datacontext
         /// </summary>
@@ -57,11 +53,11 @@ namespace Resizer.Gui.Infrastructure.Common.ViewModel
         /// <param name="e"></param>
         private static void WireViewModelChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            if(!DesignerProperties.GetIsInDesignMode(d))
+            if (!DesignerProperties.GetIsInDesignMode(d))
             {
-                if((Type)e.NewValue != (Type)e.OldValue)
+                if ((Type)e.NewValue != (Type)e.OldValue)
                 {
-                    if(s_viewmodelFactory == null)
+                    if (s_viewmodelFactory == null)
                     {
                         throw new NullReferenceException("The ViewModelLocator did not have it's factory method set");
                     }
@@ -79,7 +75,7 @@ namespace Resizer.Gui.Infrastructure.Common.ViewModel
         /// <param name="viewModel">The object to be set as the DataContext</param>
         private static void Bind(object view, object viewModel)
         {
-            if(view is FrameworkElement element)
+            if (view is FrameworkElement element)
             {
                 element.DataContext = viewModel;
             }

--- a/Source/Resizer.Gui/Settings/ApplicationSettingsView.xaml
+++ b/Source/Resizer.Gui/Settings/ApplicationSettingsView.xaml
@@ -3,9 +3,11 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:viewModel="clr-namespace:Resizer.Gui.Infrastructure.Common.ViewModel"
              xmlns:local="clr-namespace:Resizer.Gui.Settings"
              mc:Ignorable="d"
-             d:DataContext="{d:DesignInstance local:ApplicationSettingsDesignModel, IsDesignTimeCreatable=True}">
+             d:DataContext="{d:DesignInstance local:ApplicationSettingsDesignModel, IsDesignTimeCreatable=True}"
+             viewModel:ViewModelLocator.WireViewModel="{x:Type local:ApplicationSettingsViewModel}">
 
     <!-- Content -->
     <Grid>

--- a/Source/Resizer.Gui/Window/MainWindow.xaml
+++ b/Source/Resizer.Gui/Window/MainWindow.xaml
@@ -8,9 +8,11 @@
                  xmlns:converters="clr-namespace:Resizer.Gui.Infrastructure.Converters"
                  xmlns:settings="clr-namespace:Resizer.Gui.Settings"
                  xmlns:activeWindows="clr-namespace:Resizer.Gui.ActiveWindows"
+                 xmlns:viewModel="clr-namespace:Resizer.Gui.Infrastructure.Common.ViewModel"
                  xmlns:local="clr-namespace:Resizer.Gui.Window"
                  mc:Ignorable="d"
                  d:DataContext="{d:DesignInstance local:WindowDesignModel, IsDesignTimeCreatable=True}"
+                 viewModel:ViewModelLocator.WireViewModel="{x:Type local:WindowViewModel}"
                  Title="WindowResizer"
                  TitleCharacterCasing="Normal"
                  WindowTitleBrush="{DynamicResource MahApps.Brushes.WindowTitle}"
@@ -100,12 +102,12 @@
                    PaneBackground="{DynamicResource MahApps.Brushes.Flyout.Background}">
         <mah:SplitView.Pane>
             <Grid>
-                <settings:ApplicationSettingsView Margin="5" DataContext="{Binding ApplicationSettings}" />
+                <settings:ApplicationSettingsView Margin="5" />
             </Grid>
         </mah:SplitView.Pane>
         <mah:SplitView.Content>
             <Grid>
-                <activeWindows:ActiveWindowsView DataContext="{Binding ActiveWindows}" />
+                <activeWindows:ActiveWindowsView />
             </Grid>
         </mah:SplitView.Content>
     </mah:SplitView>

--- a/Source/Resizer.Gui/Window/WindowViewModel.cs
+++ b/Source/Resizer.Gui/Window/WindowViewModel.cs
@@ -44,16 +44,6 @@ namespace Resizer.Gui.Window
         private readonly IEventAggregator _eventAggregator;
 
         /// <summary>
-        /// Gets the <see cref="ApplicationSettingsViewModel"/>
-        /// </summary>
-        public IApplicationSettingsViewModel ApplicationSettings { get; }
-
-        /// <summary>
-        /// Gets the <see cref="ActiveWindowsViewModel"/>
-        /// </summary>
-        public IActiveWindowsViewModel ActiveWindows { get; }
-
-        /// <summary>
         /// Shows the project source code on Github
         /// </summary>
         public DelegateCommand ShowSourceOnGithubCommand { get; }
@@ -63,6 +53,9 @@ namespace Resizer.Gui.Window
         /// </summary>
         public DelegateCommand ShowVersionsOnGithubCommand { get; }
 
+        /// <summary>
+        /// Setup the window after it's loaded in
+        /// </summary>
         public DelegateCommand WindowLoadedCommand { get; }
 
         /// <summary>
@@ -70,12 +63,10 @@ namespace Resizer.Gui.Window
         /// //TODO fix the <see cref="WindowViewModel"/> summary
         /// </summary>
         /// <param name="generalSettings">Instance of the <see cref="ApplicationSettingsViewModel"/></param>
-        public WindowViewModel(ISettingFactory settingFactory, IEventAggregator eventAggregator, IApplicationSettingsViewModel applicationSettings, IActiveWindowsViewModel activeWindows)
+        public WindowViewModel(ISettingFactory settingFactory, IEventAggregator eventAggregator)
         {
             _settingFactory = settingFactory ?? throw new ArgumentNullException(nameof(settingFactory));
             _eventAggregator = eventAggregator ?? throw new ArgumentNullException(nameof(eventAggregator));
-            ApplicationSettings = applicationSettings ?? throw new ArgumentNullException(nameof(applicationSettings));
-            ActiveWindows = activeWindows ?? throw new ArgumentNullException(nameof(activeWindows));
 
             Version = $"v:{Assembly.GetEntryAssembly()?.GetName()?.Version?.ToString(3)}";
             ShowSourceOnGithubCommand = new DelegateCommand(() =>

--- a/Source/Resizer.Gui/Window/WindowViewModel.cs
+++ b/Source/Resizer.Gui/Window/WindowViewModel.cs
@@ -6,7 +6,6 @@ using ControlzEx.Theming;
 using Resizer.Domain.Infrastructure.Events;
 using Resizer.Domain.Infrastructure.Messenger;
 using Resizer.Domain.Settings;
-using Resizer.Gui.ActiveWindows;
 using Resizer.Gui.Infrastructure.Common.Command;
 using Resizer.Gui.Infrastructure.Common.ViewModel;
 using Resizer.Gui.Settings;

--- a/Tests/Resizer.Gui.Tests/Window/WindowViewModelTests.cs
+++ b/Tests/Resizer.Gui.Tests/Window/WindowViewModelTests.cs
@@ -1,7 +1,5 @@
 ﻿using Resizer.Domain.Tests.Infrastructure.Messenger.Mocks;
 using Resizer.Domain.Tests.Settings.Mocks;
-using Resizer.Gui.Tests.ActiveWindows.Mocks;
-using Resizer.Gui.Tests.Settings.Mocks;
 using Resizer.Gui.Window;
 using System;
 using Xunit;
@@ -21,11 +19,9 @@ namespace Resizer.Gui.Tests.Window
             // Prepare
             var settingFactoryMock = new SettingFactoryMock();
             var eventAggregatorMock = new EventAggregatorMock();
-            var applicationSettings = new ApplicationSettingsViewModelMock();
-            var activeWindows = new ActiveWindowsViewModelMock();
 
             // Act
-            var viewModel = new WindowViewModel(settingFactoryMock, eventAggregatorMock, applicationSettings, activeWindows);
+            var viewModel = new WindowViewModel(settingFactoryMock, eventAggregatorMock);
 
             // Assert
             Assert.NotNull(viewModel);
@@ -37,13 +33,11 @@ namespace Resizer.Gui.Tests.Window
             // Prepare
             var settingFactoryMock = new SettingFactoryMock();
             var eventAggregatorMock = new EventAggregatorMock();
-            var applicationSettings = new ApplicationSettingsViewModelMock();
-            var activeWindows = new ActiveWindowsViewModelMock();
 
             // Assert
             Assert.Throws<ArgumentNullException>(() =>
             {
-                var viewModel = new WindowViewModel(null!, eventAggregatorMock, applicationSettings, activeWindows);
+                var viewModel = new WindowViewModel(null!, eventAggregatorMock);
             });
         }
 
@@ -52,43 +46,11 @@ namespace Resizer.Gui.Tests.Window
         {
             // Prepare
             var settingFactoryMock = new SettingFactoryMock();
-            var applicationSettings = new ApplicationSettingsViewModelMock();
-            var activeWindows = new ActiveWindowsViewModelMock();
 
             // Assert
             Assert.Throws<ArgumentNullException>(() =>
             {
-                var viewModel = new WindowViewModel(settingFactoryMock, null!, applicationSettings, activeWindows);
-            });
-        }
-
-        [Fact]
-        public void Construct_NullApplicationSettings_ShouldThrowArgumentNullException()
-        {
-            // Prepare
-            var settingFactoryMock = new SettingFactoryMock();
-            var eventAggregatorMock = new EventAggregatorMock();
-            var activeWindows = new ActiveWindowsViewModelMock();
-
-            // Assert
-            Assert.Throws<ArgumentNullException>(() =>
-            {
-                var viewModel = new WindowViewModel(settingFactoryMock, eventAggregatorMock, null!, activeWindows);
-            });
-        }
-
-        [Fact]
-        public void Construct_NullActiveWindows_ShouldThrowArgumentNullException()
-        {
-            // Prepare
-            var settingFactoryMock = new SettingFactoryMock();
-            var eventAggregatorMock = new EventAggregatorMock();
-            var applicationSettings = new ApplicationSettingsViewModelMock();
-
-            // Assert
-            Assert.Throws<ArgumentNullException>(() =>
-            {
-                var viewModel = new WindowViewModel(settingFactoryMock, eventAggregatorMock, applicationSettings, null!);
+                var viewModel = new WindowViewModel(settingFactoryMock, null!);
             });
         }
 


### PR DESCRIPTION
## What does the pull request do?
Removes the need for god viewmodels, where a viewmodel needs to be injected with all it's child viewmodels so that child views can bind against said property.


## What is the current behavior?
Currently each viewmodel needs to have a property containing the viewmodel for each of it;s child views, creating god models that know more then they should have to.


## What is the updated/expected behavior with this PR?
A new VIewModelLocator has been added that is able to resolve a viewmodel based on a type as long as the type inhertis ViewModelBase


## How was the solution implemented (if it's not obvious)?
A delegate factory was added to Autofac that is able to resolve they now keyed viewmodels, The viewmodel locator has a attached property that takes a type of viewmodel, which when set uses the delegate factory that is injected on statup to resolve said type and set the datacontext.

## Checklist

- [ ] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?

## Breaking changes
n/a


## Fixed issues
n/a
