### PR TITLE
Move auto refresh

### DIFF
--- a/Source/Resizer.Domain/Settings/ApplicationSettings.cs
+++ b/Source/Resizer.Domain/Settings/ApplicationSettings.cs
@@ -18,9 +18,9 @@
         public bool MinimizeOnClose { get; set; } = false;
 
         /// <summary>
-        /// Gets or Sets an idicator that defines if the window should be minimized to the system tray
+        /// Gets or Sets an indicator that defines if the Active Windows list should automaticly be updated
         /// <remarks>Defaults to <see langword="false"/></remarks>
         /// </summary>
-        public bool MinimizeToSystemTray { get; set; } = false;
+        public bool AutoRefreshActiveWindows { get; set; } = false;
     }
 }

--- a/Source/Resizer.Gui/ActiveWindows/ActiveWindowsDesignModel.cs
+++ b/Source/Resizer.Gui/ActiveWindows/ActiveWindowsDesignModel.cs
@@ -24,9 +24,6 @@ namespace Resizer.Gui.ActiveWindows
         ///<inheritdoc/>
         public ICollectionView FilteredActiveWindows { get; set; }
 
-        ///<inheritdoc/>
-        public bool ShouldAutomaticallyRefresh { get; set; } = true;
-
         /// <summary>
         /// Create a new instance of the <see cref="ActiveWindowsDesignModel"/>
         /// </summary>

--- a/Source/Resizer.Gui/ActiveWindows/ActiveWindowsView.xaml
+++ b/Source/Resizer.Gui/ActiveWindows/ActiveWindowsView.xaml
@@ -2,6 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
              xmlns:converters="clr-namespace:Resizer.Gui.Infrastructure.Converters"
@@ -21,7 +22,15 @@
             </Style>
         </ResourceDictionary>
     </UserControl.Resources>
-    
+
+
+    <!-- Window Triggers -->
+    <i:Interaction.Triggers>
+        <i:EventTrigger EventName="Loaded">
+            <i:InvokeCommandAction Command="{Binding ViewLoadedCommand}" />
+        </i:EventTrigger>
+    </i:Interaction.Triggers>
+
     <Grid>
         <!-- Content -->
         <Grid>

--- a/Source/Resizer.Gui/ActiveWindows/ActiveWindowsView.xaml
+++ b/Source/Resizer.Gui/ActiveWindows/ActiveWindowsView.xaml
@@ -12,9 +12,19 @@
              viewModel:ViewModelLocator.WireViewModel="{x:Type local:ActiveWindowsViewModel}"
              d:DesignHeight="400"
              d:DesignWidth="400">
+
+    <!-- Resources -->
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <Style x:Key="DataGridTextColumnTrim" TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">
+                <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
+            </Style>
+        </ResourceDictionary>
+    </UserControl.Resources>
+    
     <Grid>
         <!-- Content -->
-        <Grid Margin="5">
+        <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition />
@@ -22,7 +32,7 @@
 
             <!-- Active Windows Settings -->
             <Grid Grid.Row="0"
-                  Margin="0 0 0 10">
+                  Margin="0 5 0 5">
                 <Grid.RowDefinitions>
                     <RowDefinition />
                     <RowDefinition />
@@ -38,18 +48,18 @@
                          Text="{Binding WindowFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                          HorizontalAlignment="Stretch"
                          VerticalAlignment="Center"
-                         Margin="0 0 5 0" />
+                         Margin="5 0 5 0" />
                 <CheckBox Grid.Row="0"
                           Grid.Column="1"
                           Content="Auto Refresh"
                           IsChecked="{Binding ShouldAutomaticallyRefresh}"
                           HorizontalAlignment="Stretch"
-                          Margin="5 2 0 2" />
+                          Margin="5 2 5 2" />
                 <Button Grid.Row="1"
                         Grid.Column="1"
                         Content="Refresh"
                         Command="{Binding RefreshActiveWindowsCommand}"
-                        Margin="5 2 0 2 " />
+                        Margin="5 2 5 2 " />
             </Grid>
 
             <!-- Active Window List -->
@@ -58,34 +68,39 @@
                       GridLinesVisibility="Vertical"
                       SelectionMode="Extended"
                       HorizontalScrollBarVisibility="Auto"
+                      VerticalScrollBarVisibility="Disabled"
                       Style="{DynamicResource MahApps.Styles.DataGrid.Azure}"
                       ItemsSource="{Binding FilteredActiveWindows}"
                       CanUserAddRows="False"
                       mah:MultiSelectorHelper.SelectedItems="{Binding SelectedActiveWindows}">
                 <DataGrid.Columns>
                     <DataGridTemplateColumn Header="Application"
-                                            Width="9*"
+                                            Width="5*"
                                             SortMemberPath="Description">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
                                 <StackPanel Orientation="Horizontal"
                                             VerticalAlignment="Center">
-                                    <Image Height="16"
+                                    <Image x:Name="WindowIcon"
+                                           Height="16"
                                            Width="16"
-                                           Margin="0 0 5 0"
+                                           Margin="5 0 5 0"
                                            Source="{Binding Icon, Converter={converters:BitmapToImageSourceConverter}}" />
-                                    <TextBlock MaxWidth="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=ActualWidth}"
+                                    <TextBlock MaxWidth="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=ActualWidth,
+                                        Converter={converters:SubtractionConverter}, ConverterParameter=26}"
                                                TextTrimming="CharacterEllipsis"
-                                               Text="{Binding Description}" />
+                                               Text="{Binding Description}"/>
                                 </StackPanel>
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
                     <DataGridTextColumn Header="PID"
-                                        Width="2*"
+                                        Width="1*"
+                                        ElementStyle="{StaticResource DataGridTextColumnTrim}"
                                         Binding="{Binding Id}" />
                     <DataGridTextColumn Header="Resolution"
-                                        Width="3*"
+                                        Width="2*"
+                                        ElementStyle="{StaticResource DataGridTextColumnTrim}"
                                         Binding="{Binding Resolution}" />
                 </DataGrid.Columns>
             </DataGrid>

--- a/Source/Resizer.Gui/ActiveWindows/ActiveWindowsView.xaml
+++ b/Source/Resizer.Gui/ActiveWindows/ActiveWindowsView.xaml
@@ -38,7 +38,7 @@
                     <RowDefinition />
                 </Grid.RowDefinitions>
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition />
+                    <ColumnDefinition  />
                     <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
                 <TextBox Grid.Row="1"
@@ -49,12 +49,12 @@
                          HorizontalAlignment="Stretch"
                          VerticalAlignment="Center"
                          Margin="5 0 5 0" />
-                <CheckBox Grid.Row="0"
+                <!--<CheckBox Grid.Row="0"
                           Grid.Column="1"
                           Content="Auto Refresh"
                           IsChecked="{Binding ShouldAutomaticallyRefresh}"
                           HorizontalAlignment="Stretch"
-                          Margin="5 2 5 2" />
+                          Margin="5 2 5 2" />-->
                 <Button Grid.Row="1"
                         Grid.Column="1"
                         Content="Refresh"
@@ -67,15 +67,15 @@
                       AutoGenerateColumns="False"
                       GridLinesVisibility="Vertical"
                       SelectionMode="Extended"
-                      HorizontalScrollBarVisibility="Auto"
-                      VerticalScrollBarVisibility="Disabled"
+                      HorizontalScrollBarVisibility="Disabled"
+                      VerticalScrollBarVisibility="Visible"
                       Style="{DynamicResource MahApps.Styles.DataGrid.Azure}"
                       ItemsSource="{Binding FilteredActiveWindows}"
                       CanUserAddRows="False"
                       mah:MultiSelectorHelper.SelectedItems="{Binding SelectedActiveWindows}">
                 <DataGrid.Columns>
                     <DataGridTemplateColumn Header="Application"
-                                            Width="5*"
+                                            Width="7*"
                                             SortMemberPath="Description">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
@@ -95,11 +95,11 @@
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
                     <DataGridTextColumn Header="PID"
-                                        Width="1*"
+                                        Width="2*"
                                         ElementStyle="{StaticResource DataGridTextColumnTrim}"
                                         Binding="{Binding Id}" />
                     <DataGridTextColumn Header="Resolution"
-                                        Width="2*"
+                                        Width="3*"
                                         ElementStyle="{StaticResource DataGridTextColumnTrim}"
                                         Binding="{Binding Resolution}" />
                 </DataGrid.Columns>

--- a/Source/Resizer.Gui/ActiveWindows/ActiveWindowsViewModel.cs
+++ b/Source/Resizer.Gui/ActiveWindows/ActiveWindowsViewModel.cs
@@ -4,6 +4,9 @@ using System.ComponentModel;
 using System.Linq;
 using System.Windows.Data;
 using System.Windows.Threading;
+using Resizer.Domain.Infrastructure.Events;
+using Resizer.Domain.Infrastructure.Messenger;
+using Resizer.Domain.Settings;
 using Resizer.Domain.Windows;
 using Resizer.Gui.Infrastructure.Common.Command;
 using Resizer.Gui.Infrastructure.Common.ViewModel;
@@ -16,6 +19,11 @@ namespace Resizer.Gui.ActiveWindows
     /// </summary>
     public class ActiveWindowsViewModel : ViewModelBase, IActiveWindowsViewModel
     {
+        /// <summary>
+        /// State that defines if the Active Windows list should automaticly refresh every 1000 miliseconds
+        /// </summary>
+        private bool _autoRefreshActiveWindows;
+
         ///<inheritdoc/>
         public ObservableCollection<Domain.Windows.Window> ActiveWindows
         {
@@ -50,13 +58,20 @@ namespace Resizer.Gui.ActiveWindows
         ///<inheritdoc/>
         public ICollectionView FilteredActiveWindows { get; set; }
 
-        ///<inheritdoc/>
-        public bool ShouldAutomaticallyRefresh { get; set; }
-
         /// <summary>
         /// <see cref="DispatcherTimer"/> used to trigger the automatic refresh
         /// </summary>
-        private readonly DispatcherTimer _autoRefreshTmer;
+        private readonly DispatcherTimer _autoRefreshTimer;
+
+        /// <summary>
+        /// <see cref="ISettingFactory"/> used to load the application settings on creation
+        /// </summary>
+        private readonly ISettingFactory _settingFactory;
+
+        /// <summary>
+        /// <see cref="IEventAggregator"/> used to be notified when the general setting have changed
+        /// </summary>
+        private readonly IEventAggregator _eventAggregator;
 
         /// <summary>
         /// <see cref="IWindowService"/> used to get all active windows
@@ -72,13 +87,17 @@ namespace Resizer.Gui.ActiveWindows
         /// Create a new instance of the <see cref="ActiveWindowsViewModel"/>
         /// </summary>
         /// <param name="windowService"><see cref="IWindowService"/> used to get all active windows</param>
-        public ActiveWindowsViewModel(IWindowService windowService)
+        public ActiveWindowsViewModel(ISettingFactory settingFactory, IEventAggregator eventAggregator, IWindowService windowService)
         {
+            _settingFactory = settingFactory ?? throw new ArgumentNullException(nameof(settingFactory));
+            _eventAggregator = eventAggregator ?? throw new ArgumentNullException(nameof(eventAggregator));
             _windowService = windowService ?? throw new ArgumentNullException(nameof(windowService));
 
+            // setup the commands
             RefreshActiveWindowsCommand = new DelegateCommand(RefreshActiveWindows);
             ActiveWindows.UpdateCollection(_windowService.GetActiveWindows().ToList());
 
+            // setup the filter view
             FilteredActiveWindows = CollectionViewSource.GetDefaultView(ActiveWindows);
             FilteredActiveWindows.Filter = w =>
             {
@@ -91,10 +110,15 @@ namespace Resizer.Gui.ActiveWindows
                 return window?.Description.Contains(WindowFilter, StringComparison.OrdinalIgnoreCase) ?? false;
             };
 
-            _autoRefreshTmer = new DispatcherTimer();
-            _autoRefreshTmer.Tick += OnAutoRefreshEvent;
-            _autoRefreshTmer.Interval = TimeSpan.FromMilliseconds(1000);
-            _autoRefreshTmer.Start();
+            // Setup the event aggregator that listens to changes to the automatic refresh
+            ApplicationSettingsChanged(_settingFactory.Create<ApplicationSettings>()); // Manualy set the application settings once as we wont be notified until something changes
+            _eventAggregator.GetEvent<SettingChangedEvent<ApplicationSettings>>().Subscribe(ApplicationSettingsChanged, ThreadOption.UIThread, false);
+
+            // Setup the refresh timer
+            _autoRefreshTimer = new DispatcherTimer();
+            _autoRefreshTimer.Tick += OnAutoRefreshEvent;
+            _autoRefreshTimer.Interval = TimeSpan.FromMilliseconds(1000);
+            _autoRefreshTimer.Start();
         }
 
         /// <summary>
@@ -113,14 +137,22 @@ namespace Resizer.Gui.ActiveWindows
         /// <param name="e"></param>
         private void OnAutoRefreshEvent(object? sender, EventArgs e)
         {
-            _autoRefreshTmer.Stop();
+            _autoRefreshTimer.Stop();
 
-            if (ShouldAutomaticallyRefresh)
+            if (_autoRefreshActiveWindows)
             {
                 RefreshActiveWindows();
             }
 
-            _autoRefreshTmer.Start();
+            _autoRefreshTimer.Start();
+        }
+
+        /// <summary>
+        /// Invoked when the general application settings have changed
+        /// </summary>
+        private void ApplicationSettingsChanged(ISetting<ApplicationSettings> settings)
+        {
+            _autoRefreshActiveWindows = settings.CurrentSetting.AutoRefreshActiveWindows;
         }
     }
 }

--- a/Source/Resizer.Gui/ActiveWindows/IActiveWindowsViewModel.cs
+++ b/Source/Resizer.Gui/ActiveWindows/IActiveWindowsViewModel.cs
@@ -27,10 +27,5 @@ namespace Resizer.Gui.ActiveWindows
         /// Gets or Sets a filtered list of all <see cref="ActiveWindows"/>
         /// </summary>
         ICollectionView FilteredActiveWindows { get; set; }
-
-        /// <summary>
-        /// Gets or Sets the state that defines if the Active Windows list should automaticly refresh every x seconds
-        /// </summary>
-        bool ShouldAutomaticallyRefresh { get; set; }
     }
 }

--- a/Source/Resizer.Gui/Infrastructure/Converters/SubtractionConverter.cs
+++ b/Source/Resizer.Gui/Infrastructure/Converters/SubtractionConverter.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Markup;
+
+namespace Resizer.Gui.Infrastructure.Converters
+{
+    /// <summary>
+    /// Defines a class that Calulates a value by subtracting a given value from the base value
+    /// </summary>
+    public class SubtractionConverter : MarkupExtension, IValueConverter
+    {
+        /// <summary>
+        /// Instance of the <see cref="RatioConverter"/>
+        /// </summary>
+        private SubtractionConverter? _instance;
+
+        /// <summary>
+        /// Provides an instance of the <see cref="SubtractionConverter"/>
+        /// </summary>
+        /// <param name="serviceProvider"></param>
+        /// <returns>Returns an instance of the <see cref="SubtractionConverter"/></returns>
+        public override object ProvideValue(IServiceProvider serviceProvider) => _instance ?? (_instance = new SubtractionConverter());
+
+
+        /// <summary>
+        /// Calculate a new <see cref="int"/> by subtracting a value
+        /// </summary>
+        /// <param name="value">The <see cref="int"/> to subtract from</param>
+        /// <param name="targetType">The type of the bound target property</param>
+        /// <param name="parameter">The <see cref="int"/> to subtract</param>
+        /// <param name="culture">The <see cref="CultureInfo"/> used during the conversion</param>
+        /// <returns>Returns a <see cref="int"/> containing the new value after subtraction</returns>
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var newValue = 0;
+            if (value != null)
+            {
+                newValue = System.Convert.ToInt32(value, CultureInfo.InvariantCulture) - System.Convert.ToInt32(parameter, CultureInfo.InvariantCulture);
+            }
+
+            return newValue;
+        }
+
+        /// <summary>
+        /// Calculate a new <see cref="int"/> by adding a value
+        /// </summary>
+        /// <param name="value">The <see cref="int"/> to add too</param>
+        /// <param name="targetType">The type of the bound target property</param>
+        /// <param name="parameter">The <see cref="int"/> to be added</param>
+        /// <param name="culture">The <see cref="CultureInfo"/> used during the conversion</param>
+        /// <returns>Returns a <see cref="int"/> containing the new value after addition</returns>
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var newValue = 0;
+            if (value != null)
+            {
+                newValue = System.Convert.ToInt32(value, CultureInfo.InvariantCulture) + System.Convert.ToInt32(parameter, CultureInfo.InvariantCulture);
+            }
+
+            return newValue;
+        }
+    }
+}

--- a/Source/Resizer.Gui/Settings/ApplicationSettingsDesignModel.cs
+++ b/Source/Resizer.Gui/Settings/ApplicationSettingsDesignModel.cs
@@ -11,6 +11,9 @@
         ///<inheritdoc/>
         public bool MinimizeOnClose { get; set; }
 
+        ///<inheritdoc/>
+        public bool AutoRefreshActiveWindows { get; set; }
+
         /// <summary>
         /// Create a new instance of the <see cref="ApplicationSettingsDesignModel"/>
         /// </summary>
@@ -18,6 +21,7 @@
         {
             UseDarkTheme = true;
             MinimizeOnClose = false;
+            AutoRefreshActiveWindows = true;
         }
     }
 }

--- a/Source/Resizer.Gui/Settings/ApplicationSettingsView.xaml
+++ b/Source/Resizer.Gui/Settings/ApplicationSettingsView.xaml
@@ -17,10 +17,12 @@
             <RowDefinition Height="auto" />
             <RowDefinition Height="32" />
             <RowDefinition Height="32" />
+            <RowDefinition Height="32" />
+            <RowDefinition Height="32" />
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition />
-            <ColumnDefinition />
+            <ColumnDefinition Width="2*"/>
+            <ColumnDefinition Width="1*"/>
         </Grid.ColumnDefinitions>
 
         <!-- Looks & Feel -->
@@ -62,5 +64,15 @@
                   VerticalAlignment="Center"
                   Margin="5"
                   IsChecked="{Binding MinimizeOnClose}" />
+        <TextBlock Grid.Row="4"
+                   Grid.Column="0"
+                   VerticalAlignment="Center"
+                   Margin="8"
+                   Text="Auto Refresh Active Windows" />
+        <CheckBox Grid.Row="4"
+                  Grid.Column="1"
+                  VerticalAlignment="Center"
+                  Margin="5"
+                  IsChecked="{Binding AutoRefreshActiveWindows}" />
     </Grid>
 </UserControl>

--- a/Source/Resizer.Gui/Settings/ApplicationSettingsViewModel.cs
+++ b/Source/Resizer.Gui/Settings/ApplicationSettingsViewModel.cs
@@ -37,6 +37,20 @@ namespace Resizer.Gui.Settings
 
         private bool _minimizeOnClose;
 
+        ///<inheritdoc/>
+        public bool AutoRefreshActiveWindows
+        {
+            get => _autoRefreshActiveWindows;
+            set
+            {
+                SetProperty(ref _autoRefreshActiveWindows, value);
+                _settings.CurrentSetting.AutoRefreshActiveWindows = value;
+                SaveSettings();
+            }
+        }
+
+        private bool _autoRefreshActiveWindows;
+
         /// <summary>
         /// <see cref="ISetting{TSetting}"/> containing the <see cref="ApplicationSettings"/>
         /// </summary>
@@ -51,6 +65,7 @@ namespace Resizer.Gui.Settings
 
             UseDarkTheme = _settings.CurrentSetting.UseDarkTheme;
             MinimizeOnClose = _settings.CurrentSetting.MinimizeOnClose;
+            AutoRefreshActiveWindows = _settings.CurrentSetting.AutoRefreshActiveWindows;
         }
 
         /// <summary>

--- a/Source/Resizer.Gui/Settings/IApplicationSettingsViewModel.cs
+++ b/Source/Resizer.Gui/Settings/IApplicationSettingsViewModel.cs
@@ -14,5 +14,10 @@
         /// Gets or Sets the state that defines if the window should be minized when closed
         /// </summary>
         bool MinimizeOnClose { get; set; }
+
+        /// <summary>
+        /// Gets or Sets the state that defines if the Active Windows should automaticly be refreshed
+        /// </summary>
+        bool AutoRefreshActiveWindows { get; set; }
     }
 }

--- a/Tests/Resizer.Gui.Tests/ActiveWindows/ActiveWindowsViewModelTests.cs
+++ b/Tests/Resizer.Gui.Tests/ActiveWindows/ActiveWindowsViewModelTests.cs
@@ -1,4 +1,6 @@
-﻿using Resizer.Domain.Tests.Windows.Mocks;
+﻿using Resizer.Domain.Tests.Infrastructure.Messenger.Mocks;
+using Resizer.Domain.Tests.Settings.Mocks;
+using Resizer.Domain.Tests.Windows.Mocks;
 using Resizer.Gui.ActiveWindows;
 using System;
 using Xunit;
@@ -13,26 +15,62 @@ namespace Resizer.Gui.Tests.ActiveWindows
         #region Constructor Tests
 
         [Fact]
-        public void Construct_NullWindowService_ShouldThrowArgumentNullException()
+        public void Construct_ValidArguments_ShouldConstructActiveWindowsViewModel()
         {
+            // Prepare
+            var settingFactoryMock = new SettingFactoryMock();
+            var eventAggregatorMock = new EventAggregatorMock();
+            var windowService = new WindowServiceMock();
+
+            // Act
+            var viewModel = new ActiveWindowsViewModel(settingFactoryMock, eventAggregatorMock, windowService);
+
+            // Assert
+            Assert.NotNull(viewModel);
+        }
+
+
+        [Fact]
+        public void Construct_NullSettingFactory_ShouldThrowArgumentNullException()
+        {
+            // Prepare 
+            var eventAggregatorMock = new EventAggregatorMock();
+            var windowService = new WindowServiceMock();
+
             // Assert
             Assert.Throws<ArgumentNullException>(() =>
             {
-                var viewModel = new ActiveWindowsViewModel(null!);
+                var viewModel = new ActiveWindowsViewModel(null!, eventAggregatorMock, windowService);
+            });
+        }
+
+
+        [Fact]
+        public void Construct_NullEventAggregator_ShouldThrowArgumentNullException()
+        {
+            // Prepare 
+            var settingFactoryMock = new SettingFactoryMock();
+            var windowService = new WindowServiceMock();
+
+            // Assert
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                var viewModel = new ActiveWindowsViewModel(settingFactoryMock, null!, windowService);
             });
         }
 
         [Fact]
-        public void Construct_ValidArguments_ShouldConstructActiveWindowsViewModel()
+        public void Construct_NullWindowService_ShouldThrowArgumentNullException()
         {
-            // Prepare
-            var windowService = new WindowServiceMock();
-
-            // Act
-            var viewModel = new ActiveWindowsViewModel(windowService);
+            // Prepare 
+            var settingFactoryMock = new SettingFactoryMock();
+            var eventAggregatorMock = new EventAggregatorMock();
 
             // Assert
-            Assert.NotNull(viewModel);
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                var viewModel = new ActiveWindowsViewModel(settingFactoryMock, eventAggregatorMock, null!);
+            });
         }
 
         #endregion Constructor Tests
@@ -43,8 +81,10 @@ namespace Resizer.Gui.Tests.ActiveWindows
         public void RefreshActiveWindows_Execution_ShouldCallWindowService()
         {
             // Prepare
+            var settingFactoryMock = new SettingFactoryMock();
+            var eventAggregatorMock = new EventAggregatorMock();
             var windowService = new WindowServiceMock();
-            var viewmodel = new ActiveWindowsViewModel(windowService);
+            var viewmodel = new ActiveWindowsViewModel(settingFactoryMock, eventAggregatorMock, windowService);
 
             // Act
             windowService.GetActiveWindowsCalled = false;

--- a/Tests/Resizer.Gui.Tests/Settings/Mocks/ApplicationSettingsViewModelMock.cs
+++ b/Tests/Resizer.Gui.Tests/Settings/Mocks/ApplicationSettingsViewModelMock.cs
@@ -12,5 +12,8 @@ namespace Resizer.Gui.Tests.Settings.Mocks
 
         ///<inheritdoc/>
         public bool MinimizeOnClose { get; set; }
+
+        ///<inheritdoc/>
+        public bool AutoRefreshActiveWindows { get; set; }
     }
 }


### PR DESCRIPTION
## What does the pull request do?
Moves the auto refresh of the active windows to the settings


## What is the current behavior?
Currently the active windows view has an extra checkbox that enabled auto refresh of the active window list.


## What is the updated/expected behavior with this PR?
The auto refresh button has been moved to the settings tab, this cleans up the UI, and suits better as a general setting as this will mean it get's saved and always automaticly enabled/disabled when the resizer is started

## How was the solution implemented (if it's not obvious)?
ActiveWindowsViewModel now has a reference for the event aggregator to listen for settings changes and the settings factory to see what the current setting is.


## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?

## Breaking changes
n/a


## Fixed issues
n/a
