### PR TITLE
Update CD/CI badges to use shield.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@
     </a>
     <br>
     <!-- CD/CI Badges-->
-    <a href="https://github.com/AKruimink/WinReform/actions?query=workflow%3A%22master+build%22">
-        <img src="https://github.com/AKruimink/WinReform/workflows/develop%20build/badge.svg?branch=master">
+    <a href="https://github.com/AKruimink/WinReform/actions?query=workflow%3Abuild-project">
+        <img src="https://github.com/AKruimink/WinReform/workflows/build-project/badge.svg?branch=master&event=push">
     </a>
-    <a href="https://github.com/AKruimink/WinReform/actions?query=workflow%3A%22develop+build%22">
-        <img src="https://github.com/AKruimink/WinReform/workflows/develop%20build/badge.svg?branch=develop">
+    <a href="https://github.com/AKruimink/WinReform/actions?query=workflow%3Abuild-project">
+        <img src="https://github.com/AKruimink/WinReform/workflows/build-project/badge.svg?branch=develop&event=push">
     </a>
-    <a href="https://github.com/AKruimink/WinReform/actions?query=workflow%3A%22unit+tests%22">
-        <img src="https://github.com/AKruimink/WinReform/workflows/unit%20tests/badge.svg">
+    <a href="https://github.com/AKruimink/WinReform/actions?query=workflow%3Atest-project">
+        <img src="https://github.com/AKruimink/WinReform/workflows/test-project/badge.svg?branch=develop&event=push">
     </a>
     <br>
     <!--Issues and Pull Request Badges -->

--- a/README.md
+++ b/README.md
@@ -7,10 +7,8 @@
     <p>
         A simple tool to help resize and relocate stubborn windows.
     </p>
-  </a>
-</div>
-<!-- Project Info Badges -->
-<a href="https://github.com/nblockchain/AKruimink/WinReform/develop/LICENCE.md">
+    <!-- Project Info Badges -->
+    <a href="https://github.com/nblockchain/AKruimink/WinReform/develop/LICENCE.md">
         <img src="https://img.shields.io/github/license/AKruimink/WinReform.svg?label=license&style=flat-square">
     </a>
     <a href="https://github.com/AKruimink/WinReform/releases/latest">
@@ -41,6 +39,9 @@
     <a href="https://github.com/AKruimink/WinReform/pulls">
         <img src="https://img.shields.io/github/issues-pr-closed-raw/AKruimink/WinReform.svg?label=closed%20pull%20requests&style=flat-square">
     </a>
+  </a>
+</div>
+
 
 ## About
 WinReform is a utility tool that exists to solve resolution issues with older applications.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
     </p>
   </a>
 </div>
-https://img.shields.io/github/workflow/status/AKruimink/WinReform/build-project.svg?label=release&style=flat-square&branch=develop&event=push
 <!-- Project Info Badges -->
 <a href="https://github.com/nblockchain/AKruimink/WinReform/develop/LICENCE.md">
         <img src="https://img.shields.io/github/license/AKruimink/WinReform.svg?label=license&style=flat-square">

--- a/README.md
+++ b/README.md
@@ -6,7 +6,13 @@
     <p>
         A simple tool to help resize and relocate stubborn windows.
     </p>
-    <!-- Project Info Badges -->
+  </a>
+</div>
+
+<!-- Project Info Badges -->
+[![license](https://img.shields.io/github/license/AKruimink/WinReform.svg?style=flat-square)](https://github.com/nblockchain/AKruimink/WinReform/develop/LICENCE.md)
+[![release](https://img.shields.io/github/release/AKruimink/WinReform.svg?style=flat-square)](https://github.com/AKruimink/WinReform/releases/latest)
+    
     <a href="https://github.com/nblockchain/AKruimink/WinReform/develop/LICENCE.md">
         <img src="https://img.shields.io/github/license/AKruimink/WinReform.svg?style=flat-square">
     </a>
@@ -38,8 +44,7 @@
     <a href="https://github.com/AKruimink/WinReform/pulls">
         <img src="https://img.shields.io/github/issues-pr-closed-raw/AKruimink/WinReform.svg?style=flat-square">
     </a>
-  </a>
-</div>
+
 
 ## About
 WinReform is a utility tool that exists to solve resolution issues with older applications.

--- a/README.md
+++ b/README.md
@@ -9,38 +9,38 @@
     </p>
   </a>
 </div>
-
+https://img.shields.io/github/workflow/status/AKruimink/WinReform/build-project.svg?label=release&style=flat-square&branch=develop&event=push
 <!-- Project Info Badges -->
 <a href="https://github.com/nblockchain/AKruimink/WinReform/develop/LICENCE.md">
-        <img src="https://img.shields.io/github/license/AKruimink/WinReform.svg?label=license?style=flat-square">
+        <img src="https://img.shields.io/github/license/AKruimink/WinReform.svg?label=license&style=flat-square">
     </a>
     <a href="https://github.com/AKruimink/WinReform/releases/latest">
-        <img src="https://img.shields.io/github/release/AKruimink/WinReform.svg?label=release?style=flat-square">
+        <img src="https://img.shields.io/github/release/AKruimink/WinReform.svg?label=release&style=flat-square">
     </a>
     <br>
     <!-- CD/CI Badges-->
     <a href="https://github.com/AKruimink/WinReform/actions?query=workflow%3Abuild-project">
-        <img src="https://github.com/AKruimink/WinReform/workflows/build-project/badge.svg?label=master&branch=master&event=push">
+        <img src="https://img.shields.io/github/workflow/status/AKruimink/WinReform/build-project/master?label=master&style=flat-square">
     </a>
     <a href="https://github.com/AKruimink/WinReform/actions?query=workflow%3Abuild-project">
-        <img src="https://github.com/AKruimink/WinReform/workflows/build-project/badge.svg?text=develop?branch=develop&event=push">
+        <img src="https://img.shields.io/github/workflow/status/AKruimink/WinReform/build-project/develop?label=develop&style=flat-square">
     </a>
     <a href="https://github.com/AKruimink/WinReform/actions?query=workflow%3Atest-project">
-        <img src="https://github.com/AKruimink/WinReform/workflows/test-project/badge.svg?text=tests&branch=develop&event=push">
+        <img src="https://img.shields.io/github/workflow/status/AKruimink/WinReform/test-project/develop?label=tests&style=flat-square">
     </a>
     <br>
     <!--Issues and Pull Request Badges -->
     <a href="https://github.com/AKruimink/WinReform/issues">
-        <img src="https://img.shields.io/github/issues-raw/AKruimink/WinReform.svg?label=open%issues?style=flat-square">
+        <img src="https://img.shields.io/github/issues-raw/AKruimink/WinReform.svg?label=open%20issues&style=flat-square">
     </a>
     <a href="https://github.com/AKruimink/WinReform/issues">
-        <img src="https://img.shields.io/github/issues-closed-raw/AKruimink/WinReform.svg?label=closed%issues?style=flat-square">
+        <img src="https://img.shields.io/github/issues-closed-raw/AKruimink/WinReform.svg?label=closed%20issues&style=flat-square">
     </a>
     <a href="https://github.com/AKruimink/WinReform/pulls">
-        <img src="https://img.shields.io/github/issues-pr-raw/AKruimink/WinReform.svg?label=open%pull%requests?style=flat-square">
+        <img src="https://img.shields.io/github/issues-pr-raw/AKruimink/WinReform.svg?label=open%20pull%20requests&style=flat-square">
     </a>
     <a href="https://github.com/AKruimink/WinReform/pulls">
-        <img src="https://img.shields.io/github/issues-pr-closed-raw/AKruimink/WinReform.svg?label=closed%pull%requests?style=flat-square">
+        <img src="https://img.shields.io/github/issues-pr-closed-raw/AKruimink/WinReform.svg?label=closed%20pull%20requests&style=flat-square">
     </a>
 
 ## About

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- Markdown doesnt like aligning stuff -->
 <div align="center">
     <a href="https://github.com/AKruimink/WinReform">
         <img alt="WinReform" height="200" width="200" src="https://raw.githubusercontent.com/AKruimink/WinReform/develop/docs/logo.png">
@@ -10,41 +11,37 @@
 </div>
 
 <!-- Project Info Badges -->
-[![license](https://img.shields.io/github/license/AKruimink/WinReform.svg?style=flat-square)](https://github.com/nblockchain/AKruimink/WinReform/develop/LICENCE.md)
-[![release](https://img.shields.io/github/release/AKruimink/WinReform.svg?style=flat-square)](https://github.com/AKruimink/WinReform/releases/latest)
-    
-    <a href="https://github.com/nblockchain/AKruimink/WinReform/develop/LICENCE.md">
-        <img src="https://img.shields.io/github/license/AKruimink/WinReform.svg?style=flat-square">
+<a href="https://github.com/nblockchain/AKruimink/WinReform/develop/LICENCE.md">
+        <img src="https://img.shields.io/github/license/AKruimink/WinReform.svg?label=license?style=flat-square">
     </a>
     <a href="https://github.com/AKruimink/WinReform/releases/latest">
-        <img src="https://img.shields.io/github/release/AKruimink/WinReform.svg?style=flat-square">
+        <img src="https://img.shields.io/github/release/AKruimink/WinReform.svg?label=release?style=flat-square">
     </a>
     <br>
     <!-- CD/CI Badges-->
     <a href="https://github.com/AKruimink/WinReform/actions?query=workflow%3Abuild-project">
-        <img src="https://github.com/AKruimink/WinReform/workflows/build-project/badge.svg?branch=master&event=push">
+        <img src="https://github.com/AKruimink/WinReform/workflows/build-project/badge.svg?label=master?branch=master&event=push">
     </a>
     <a href="https://github.com/AKruimink/WinReform/actions?query=workflow%3Abuild-project">
-        <img src="https://github.com/AKruimink/WinReform/workflows/build-project/badge.svg?branch=develop&event=push">
+        <img src="https://github.com/AKruimink/WinReform/workflows/build-project/badge.svg?label=develop?branch=develop&event=push">
     </a>
     <a href="https://github.com/AKruimink/WinReform/actions?query=workflow%3Atest-project">
-        <img src="https://github.com/AKruimink/WinReform/workflows/test-project/badge.svg?branch=develop&event=push">
+        <img src="https://github.com/AKruimink/WinReform/workflows/test-project/badge.svg?label=tests?branch=develop&event=push">
     </a>
     <br>
     <!--Issues and Pull Request Badges -->
     <a href="https://github.com/AKruimink/WinReform/issues">
-        <img src="https://img.shields.io/github/issues-raw/AKruimink/WinReform.svg?style=flat-square">
+        <img src="https://img.shields.io/github/issues-raw/AKruimink/WinReform.svg?label=open%issues?style=flat-square">
     </a>
     <a href="https://github.com/AKruimink/WinReform/issues">
-        <img src="https://img.shields.io/github/issues-closed-raw/AKruimink/WinReform.svg?style=flat-square">
+        <img src="https://img.shields.io/github/issues-closed-raw/AKruimink/WinReform.svg?label=closed%issues?style=flat-square">
     </a>
     <a href="https://github.com/AKruimink/WinReform/pulls">
-        <img src="https://img.shields.io/github/issues-pr-raw/AKruimink/WinReform.svg?style=flat-square">
+        <img src="https://img.shields.io/github/issues-pr-raw/AKruimink/WinReform.svg?label=open%pull%requests?style=flat-square">
     </a>
     <a href="https://github.com/AKruimink/WinReform/pulls">
-        <img src="https://img.shields.io/github/issues-pr-closed-raw/AKruimink/WinReform.svg?style=flat-square">
+        <img src="https://img.shields.io/github/issues-pr-closed-raw/AKruimink/WinReform.svg?label=closed%pull%requests?style=flat-square">
     </a>
-
 
 ## About
 WinReform is a utility tool that exists to solve resolution issues with older applications.

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@
     <br>
     <!-- CD/CI Badges-->
     <a href="https://github.com/AKruimink/WinReform/actions?query=workflow%3Abuild-project">
-        <img src="https://github.com/AKruimink/WinReform/workflows/build-project/badge.svg?label=master?branch=master&event=push">
+        <img src="https://github.com/AKruimink/WinReform/workflows/build-project/badge.svg?label=master&branch=master&event=push">
     </a>
     <a href="https://github.com/AKruimink/WinReform/actions?query=workflow%3Abuild-project">
-        <img src="https://github.com/AKruimink/WinReform/workflows/build-project/badge.svg?label=develop?branch=develop&event=push">
+        <img src="https://github.com/AKruimink/WinReform/workflows/build-project/badge.svg?text=develop?branch=develop&event=push">
     </a>
     <a href="https://github.com/AKruimink/WinReform/actions?query=workflow%3Atest-project">
-        <img src="https://github.com/AKruimink/WinReform/workflows/test-project/badge.svg?label=tests?branch=develop&event=push">
+        <img src="https://github.com/AKruimink/WinReform/workflows/test-project/badge.svg?text=tests&branch=develop&event=push">
     </a>
     <br>
     <!--Issues and Pull Request Badges -->


### PR DESCRIPTION
## What does the pull request do?
Update the cd/ci badges to use shield.io


## What is the current behavior?
Currently the cd/ci badges show the labels provided by the workflow, not clearly defining what the badge indicates


## What is the updated/expected behavior with this PR?
The badges now use shield.io which allows an edit of the labels


## How was the solution implemented (if it's not obvious)?
n/a


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?

## Breaking changes
n/a


## Fixed issues
n/a
