### PR TITLE
#28 fix crash on resolution double click

### DIFF
--- a/src/WinReform/WinReform.Gui/ActiveWindows/ActiveWindowsView.xaml
+++ b/src/WinReform/WinReform.Gui/ActiveWindows/ActiveWindowsView.xaml
@@ -68,7 +68,7 @@
                       SelectionMode="Extended"
                       HorizontalScrollBarVisibility="Disabled"
                       VerticalScrollBarVisibility="Visible"
-                      Style="{DynamicResource MahApps.Styles.DataGrid.Azure}"
+                      Style="{DynamicResource MahApps.Styles.DataGrid}"
                       ItemsSource="{Binding FilteredActiveWindows}"
                       CanUserAddRows="False"
                       IsReadOnly="True"

--- a/src/WinReform/WinReform.Gui/ActiveWindows/ActiveWindowsView.xaml
+++ b/src/WinReform/WinReform.Gui/ActiveWindows/ActiveWindowsView.xaml
@@ -71,6 +71,7 @@
                       Style="{DynamicResource MahApps.Styles.DataGrid.Azure}"
                       ItemsSource="{Binding FilteredActiveWindows}"
                       CanUserAddRows="False"
+                      IsReadOnly="True"
                       mah:MultiSelectorHelper.SelectedItems="{Binding SelectedActiveWindows}">
                 <DataGrid.Columns>
                     <DataGridTemplateColumn Header="Application"


### PR DESCRIPTION
## What does the pull request do?
Fixes the issue where the application would crash when Resolution in the ActiveWindowView was double clicked


## What is the current behavior?
Currently when the Resolution is double clicked the application crashes, this due to it trying to edit the value but the Resoltuions tab is bound to a get only property, causing an exception.


## What is the updated/expected behavior with this PR?
Now when double clicken any cell for that matter no edit is attempted.


## How was the solution implemented (if it's not obvious)?
DataGrid has been made read only, as there is no reason for it to be edited to begin with, the datagrid style has also been adjusted as some people had issues differentiating between selected and not selected items.

## Checklist

- [x] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?

## Breaking changes
n/a


## Fixed issues
Fixes #28