### PR TITLE
[WIP] #23 add support for lower resolutions

### DIFF
--- a/src/WinReform/WinReform.Gui/Window/MainWindow.xaml
+++ b/src/WinReform/WinReform.Gui/Window/MainWindow.xaml
@@ -2,7 +2,6 @@
                  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-                 xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
                  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                  xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
                  xmlns:converters="clr-namespace:WinReform.Gui.Infrastructure.Converters"
@@ -27,9 +26,9 @@
                  WindowStartupLocation="CenterScreen"
                  Closing="MetroWindow_Closing"
                  Width="{Binding Source={x:Static SystemParameters.PrimaryScreenWidth}, Converter={converters:RatioConverter}, ConverterParameter='0.20'}"
-                 MinWidth="300"
+                 MinWidth="315"
                  Height="{Binding Source={x:Static SystemParameters.PrimaryScreenHeight}, Converter={converters:RatioConverter}, ConverterParameter='0.35'}"
-                 MinHeight="350"
+                 MinHeight="315"
                  SizeChanged="WinReformSizeChanged">
 
     <!-- Resources used in the view -->

--- a/src/WinReform/WinReform.Gui/Window/MainWindow.xaml
+++ b/src/WinReform/WinReform.Gui/Window/MainWindow.xaml
@@ -46,6 +46,11 @@
     <!-- Left title items -->
     <mah:MetroWindow.LeftWindowCommands>
         <mah:WindowCommands>
+            <mah:WindowCommands.LayoutTransform>
+                <ScaleTransform ScaleX="{Binding ElementName=WinReformWindow, Path=ScaleValue}"
+                                ScaleY="{Binding ElementName=WinReformWindow, Path=ScaleValue}" />
+            </mah:WindowCommands.LayoutTransform>
+
             <StackPanel Orientation="Horizontal">
                 <ToggleButton Height="24"
                               Width="24"
@@ -80,6 +85,11 @@
     <!-- Right title items -->
     <mah:MetroWindow.RightWindowCommands>
         <mah:WindowCommands>
+            <mah:WindowCommands.LayoutTransform>
+                <ScaleTransform ScaleX="{Binding ElementName=WinReformWindow, Path=ScaleValue}"
+                                ScaleY="{Binding ElementName=WinReformWindow, Path=ScaleValue}" />
+            </mah:WindowCommands.LayoutTransform>
+            
             <Button Command="{Binding ShowVersionsOnGithubCommand}"
                     ToolTip="Versions on Github">
                 <TextBlock Text="{Binding Version}"
@@ -101,8 +111,8 @@
                    IsPaneOpen="{Binding MenuIsOpen, Mode=TwoWay}"
                    PaneBackground="{DynamicResource MahApps.Brushes.Flyout.Background}">
         <mah:SplitView.LayoutTransform>
-            <ScaleTransform ScaleX="{Binding ElementName=WinReformWindow, Path=ScaleValue}" 
-                            ScaleY="{Binding ElementName=WinReformWindow, Path=ScaleValue}"/>
+            <ScaleTransform ScaleX="{Binding ElementName=WinReformWindow, Path=ScaleValue}"
+                            ScaleY="{Binding ElementName=WinReformWindow, Path=ScaleValue}" />
         </mah:SplitView.LayoutTransform>
         <mah:SplitView.Pane>
             <Grid>

--- a/src/WinReform/WinReform.Gui/Window/MainWindow.xaml
+++ b/src/WinReform/WinReform.Gui/Window/MainWindow.xaml
@@ -16,6 +16,7 @@
                  mc:Ignorable="d"
                  d:DataContext="{d:DesignInstance local:WindowDesignModel, IsDesignTimeCreatable=True}"
                  viewModel:ViewModelLocator.WireViewModel="{x:Type local:WindowViewModel}"
+                 Name="WinReformWindow"
                  Icon="../Infrastructure/Resources/WinReform.ico"
                  ShowIconOnTitleBar="False"
                  Title="WinReform"
@@ -25,10 +26,11 @@
                  UseLayoutRounding="True"
                  WindowStartupLocation="CenterScreen"
                  Closing="MetroWindow_Closing"
-                 Height="{Binding Source={x:Static SystemParameters.PrimaryScreenHeight}, Converter={converters:RatioConverter}, ConverterParameter='0.4'}"
-                 MinHeight="{Binding Source={x:Static SystemParameters.PrimaryScreenHeight}, Converter={converters:RatioConverter}, ConverterParameter='0.4'}"
-                 Width="{Binding Source={x:Static SystemParameters.PrimaryScreenWidth}, Converter={converters:RatioConverter}, ConverterParameter='0.21'}"
-                 MinWidth="{Binding Source={x:Static SystemParameters.PrimaryScreenWidth}, Converter={converters:RatioConverter}, ConverterParameter='0.21'}">
+                 Width="{Binding Source={x:Static SystemParameters.PrimaryScreenWidth}, Converter={converters:RatioConverter}, ConverterParameter='0.20'}"
+                 MinWidth="300"
+                 Height="{Binding Source={x:Static SystemParameters.PrimaryScreenHeight}, Converter={converters:RatioConverter}, ConverterParameter='0.35'}"
+                 MinHeight="350"
+                 SizeChanged="WinReformSizeChanged">
 
     <!-- Resources used in the view -->
     <mah:MetroWindow.Resources>
@@ -98,6 +100,10 @@
                    OverlayBrush="{StaticResource Splitview.Overlay}"
                    IsPaneOpen="{Binding MenuIsOpen, Mode=TwoWay}"
                    PaneBackground="{DynamicResource MahApps.Brushes.Flyout.Background}">
+        <mah:SplitView.LayoutTransform>
+            <ScaleTransform ScaleX="{Binding ElementName=WinReformWindow, Path=ScaleValue}" 
+                            ScaleY="{Binding ElementName=WinReformWindow, Path=ScaleValue}"/>
+        </mah:SplitView.LayoutTransform>
         <mah:SplitView.Pane>
             <Grid>
                 <settings:ApplicationSettingsView Margin="5" />

--- a/src/WinReform/WinReform.Gui/Window/MainWindow.xaml.cs
+++ b/src/WinReform/WinReform.Gui/Window/MainWindow.xaml.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.ComponentModel;
-using System.Runtime.CompilerServices;
 using System.Windows;
 using MahApps.Metro.Controls;
 using WinReform.Gui.Window;
@@ -15,11 +14,11 @@ namespace WinReform.Gui
         /// <summary>
         /// Gets or Sets the scale value used to scale transform elements based on current application resolution
         /// </summary>
-        public static readonly DependencyProperty ScaleValueProperty = 
+        public static readonly DependencyProperty ScaleValueProperty =
             DependencyProperty.Register(
-                "ScaleValue", 
-                typeof(double), 
-                typeof(MainWindow), 
+                "ScaleValue",
+                typeof(double),
+                typeof(MainWindow),
                 new UIPropertyMetadata(1.0, new PropertyChangedCallback(OnScaleValueChanged), new CoerceValueCallback(OnCoerceScaleValue)));
 
         /// <summary>
@@ -48,14 +47,14 @@ namespace WinReform.Gui
 
             newValue = Math.Min(MaximumScaleValue, (double)value);
             newValue = Math.Max(MinimumScaleValue, newValue);
-            
+
             return newValue;
         }
 
         /// <summary>
         /// Gets the maximum scale value allowed
         /// </summary>
-        public static  double MaximumScaleValue { get; } = 1.0d;
+        public static double MaximumScaleValue { get; } = 1.0d;
 
         /// <summary>
         /// Gets the minimum scale value allowed

--- a/src/WinReform/WinReform.Gui/Window/MainWindow.xaml.cs
+++ b/src/WinReform/WinReform.Gui/Window/MainWindow.xaml.cs
@@ -1,4 +1,6 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using System.Windows;
 using MahApps.Metro.Controls;
 using WinReform.Gui.Window;
@@ -78,6 +80,14 @@ namespace WinReform.Gui
         }
 
         /// <summary>
+        /// Calculates a new scale value based on the actual width and height of the application
+        /// </summary>
+        private double CalculateScale()
+        {
+            return Math.Min(ActualWidth / 500d, ActualHeight / 400d);
+        }
+
+        /// <summary>
         /// Triggers when the application is closed and handles closing or minimizing of the application
         /// TODO: Fix the Window Minimize on close to only work with the Close button, all other ways of closing the app should just close as expected
         /// WinForms has a CloseReason which seems to be non existing for WPF
@@ -96,6 +106,16 @@ namespace WinReform.Gui
             }
 
             Application.Current.Shutdown();
+        }
+
+        /// <summary>
+        /// Fires each time the <see cref="MainWindow"/> changes size and updates the scale accordingly
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void WinReformSizeChanged(object sender, EventArgs e)
+        {
+            ScaleValue = (double)OnCoerceScaleValue(WinReformWindow, CalculateScale());
         }
     }
 }

--- a/src/WinReform/WinReform.Gui/Window/MainWindow.xaml.cs
+++ b/src/WinReform/WinReform.Gui/Window/MainWindow.xaml.cs
@@ -11,6 +11,65 @@ namespace WinReform.Gui
     public partial class MainWindow : MetroWindow
     {
         /// <summary>
+        /// Gets or Sets the scale value used to scale transform elements based on current application resolution
+        /// </summary>
+        public static readonly DependencyProperty ScaleValueProperty = 
+            DependencyProperty.Register(
+                "ScaleValue", 
+                typeof(double), 
+                typeof(MainWindow), 
+                new UIPropertyMetadata(1.0, new PropertyChangedCallback(OnScaleValueChanged), new CoerceValueCallback(OnCoerceScaleValue)));
+
+        /// <summary>
+        /// Invoked every time <see cref="ScaleValueProperty"/> changed it value
+        /// </summary>
+        /// <param name="o"></param>
+        /// <param name="e"></param>
+        private static void OnScaleValueChanged(DependencyObject o, DependencyPropertyChangedEventArgs e)
+        {
+        }
+
+        /// <summary>
+        /// Invoked each time <see cref="ScaleValueProperty"/> changed regardless if the value is different then the previouse and validates the new value
+        /// </summary>
+        /// <param name="o"></param>
+        /// <param name="value"></param>
+        /// <returns>Returns <see cref="double"/> with the validated scale value</returns>
+        private static object OnCoerceScaleValue(DependencyObject o, object value)
+        {
+            var newValue = 1.0d;
+
+            if (double.IsNaN((double)value))
+            {
+                return newValue;
+            }
+
+            newValue = Math.Min(MaximumScaleValue, (double)value);
+            newValue = Math.Max(MinimumScaleValue, newValue);
+            
+            return newValue;
+        }
+
+        /// <summary>
+        /// Gets the maximum scale value allowed
+        /// </summary>
+        public static  double MaximumScaleValue { get; } = 1.0d;
+
+        /// <summary>
+        /// Gets the minimum scale value allowed
+        /// </summary>
+        public static double MinimumScaleValue { get; } = 0.7d;
+
+        /// <summary>
+        /// Gets or Sets the scale value used to scale transform the application
+        /// </summary>
+        public double ScaleValue
+        {
+            get => (double)GetValue(ScaleValueProperty);
+            set => SetValue(ScaleValueProperty, value);
+        }
+
+        /// <summary>
         /// Create a new instance of <see cref="MainWindow"/>
         /// </summary>
         public MainWindow()


### PR DESCRIPTION
## What does the pull request do?
Adds the ability to rescale the application to support resolution down to atleast 1024 x 768


## What is the current behavior?
Currently when the resolution goes below 1920 x 1080 allot of the elements will no longer fit on screen.


## What is the updated/expected behavior with this PR?
When the application is ran on a window lower then 1920 x 1080 the elements and fonts will nicely scale down.


## How was the solution implemented (if it's not obvious)?
The default window width and height ratio's have been slightly ajusted.
The minimum width and height have ben replaced with hard coded values to set a limit to avoid pixelated text
A depndency property has been added to handle the scale value that is bound to by the ScaleTransform that now handles the application scaling


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?

## Breaking changes
n/a


## Fixed issues
Fixes #23 
