### PR TITLE
#19 add location column to Active Windows

### DIFF
--- a/src/WinReform/WinReform.Domain/Settings/ApplicationSettings.cs
+++ b/src/WinReform/WinReform.Domain/Settings/ApplicationSettings.cs
@@ -12,6 +12,12 @@
         public bool UseDarkTheme { get; set; } = false;
 
         /// <summary>
+        /// Gets or Sets an indicator that defines if the PID of Active Windows should be replaced with the window location
+        /// <remarks>Defaults to <see langword="false"/></remarks>
+        /// </summary>
+        public bool DisplayActiveWindowLocation { get; set; } = false;
+
+        /// <summary>
         /// Gets or Sets an idicator that defines if the window should be minimized when closed
         /// <remarks>Defaults to <see langword="false"/></remarks>
         /// </summary>

--- a/src/WinReform/WinReform.Domain/Settings/SettingStore.cs
+++ b/src/WinReform/WinReform.Domain/Settings/SettingStore.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Xml;
@@ -22,7 +23,11 @@ namespace WinReform.Domain.Settings
         /// </summary>
         public SettingStore()
         {
+            _filePath = $"{Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)}\\{Assembly.GetEntryAssembly()?.GetName().Name}";
+
+#if DEBUG
             _filePath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+#endif
         }
 
         ///<inheritdoc/>

--- a/src/WinReform/WinReform.Domain/Settings/SettingStore.cs
+++ b/src/WinReform/WinReform.Domain/Settings/SettingStore.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Xml;

--- a/src/WinReform/WinReform.Domain/Windows/Window.cs
+++ b/src/WinReform/WinReform.Domain/Windows/Window.cs
@@ -69,6 +69,12 @@ namespace WinReform.Domain.Windows
         private Rect _dimensions;
 
         /// <summary>
+        /// Gets the location of the application within the virtual space
+        /// </summary>
+        [DependsOnProperty(nameof(Dimensions))]
+        public string Location => $"{Dimensions.Left} x {Dimensions.Top}";
+
+        /// <summary>
         /// Gets the resolution of the application
         /// </summary>
         [DependsOnProperty(nameof(Dimensions))]

--- a/src/WinReform/WinReform.Gui/ActiveWindows/ActiveWindowsDesignModel.cs
+++ b/src/WinReform/WinReform.Gui/ActiveWindows/ActiveWindowsDesignModel.cs
@@ -14,6 +14,9 @@ namespace WinReform.Gui.ActiveWindows
     public class ActiveWindowsDesignModel : IActiveWindowsViewModel
     {
         ///<inheritdoc/>
+        public bool DisplayLocation { get; set; }
+
+        ///<inheritdoc/>
         public ObservableCollection<Domain.Windows.Window> ActiveWindows { get; set; } = new ObservableCollection<Domain.Windows.Window>();
 
         ///<inheritdoc/>
@@ -30,6 +33,8 @@ namespace WinReform.Gui.ActiveWindows
         /// </summary>
         public ActiveWindowsDesignModel()
         {
+            DisplayLocation = false;
+
             var windows = new List<Domain.Windows.Window>
             {
                 new Domain.Windows.Window

--- a/src/WinReform/WinReform.Gui/ActiveWindows/ActiveWindowsView.xaml
+++ b/src/WinReform/WinReform.Gui/ActiveWindows/ActiveWindowsView.xaml
@@ -24,7 +24,7 @@
     </UserControl.Resources>
 
     <Grid>
-        <FrameworkElement x:Name="dataContextElement" Visibility="Collapsed"/>
+        <FrameworkElement x:Name="dataContextElement" Visibility="Collapsed" />
         <!-- Content -->
         <Grid>
             <Grid.RowDefinitions>
@@ -102,7 +102,7 @@
                                         Binding="{Binding Id}">
                         <DataGridTextColumn.CellStyle>
                             <Style BasedOn="{StaticResource MahApps.Styles.DataGridCell}" TargetType="DataGridCell">
-                                <Setter Property="ToolTip" Value="The unique identifier assigned to the window"/>
+                                <Setter Property="ToolTip" Value="The unique identifier assigned to the window" />
                             </Style>
                         </DataGridTextColumn.CellStyle>
                     </DataGridTextColumn>
@@ -113,7 +113,7 @@
                                         Binding="{Binding Location}">
                         <DataGridTextColumn.CellStyle>
                             <Style BasedOn="{StaticResource MahApps.Styles.DataGridCell}" TargetType="DataGridCell">
-                                <Setter Property="ToolTip" Value="The current window location inside the virtual space"/>
+                                <Setter Property="ToolTip" Value="The current window location inside the virtual space" />
                             </Style>
                         </DataGridTextColumn.CellStyle>
                     </DataGridTextColumn>
@@ -123,7 +123,7 @@
                                         Binding="{Binding Resolution}">
                         <DataGridTextColumn.CellStyle>
                             <Style BasedOn="{StaticResource MahApps.Styles.DataGridCell}" TargetType="DataGridCell">
-                                <Setter Property="ToolTip" Value="The current window resolution"/>
+                                <Setter Property="ToolTip" Value="The current window resolution" />
                             </Style>
                         </DataGridTextColumn.CellStyle>
                     </DataGridTextColumn>

--- a/src/WinReform/WinReform.Gui/ActiveWindows/ActiveWindowsView.xaml
+++ b/src/WinReform/WinReform.Gui/ActiveWindows/ActiveWindowsView.xaml
@@ -24,6 +24,7 @@
     </UserControl.Resources>
 
     <Grid>
+        <FrameworkElement x:Name="dataContextElement" Visibility="Collapsed"/>
         <!-- Content -->
         <Grid>
             <Grid.RowDefinitions>
@@ -96,6 +97,7 @@
                     </DataGridTemplateColumn>
                     <DataGridTextColumn Header="PID"
                                         Width="2*"
+                                        Visibility="{Binding DataContext.DisplayLocation, Converter={converters:InvertedBooleanToVisibilityConverter}, Source={x:Reference dataContextElement}, Mode=TwoWay}"
                                         ElementStyle="{StaticResource DataGridTextColumnTrim}"
                                         Binding="{Binding Id}">
                         <DataGridTextColumn.CellStyle>
@@ -106,6 +108,7 @@
                     </DataGridTextColumn>
                     <DataGridTextColumn Header="Location"
                                         Width="4*"
+                                    Visibility="{Binding DataContext.DisplayLocation, Converter={converters:BooleanToVisibilityConverter}, Source={x:Reference dataContextElement}, Mode=TwoWay}"
                                         ElementStyle="{StaticResource DataGridTextColumnTrim}"
                                         Binding="{Binding Location}">
                         <DataGridTextColumn.CellStyle>

--- a/src/WinReform/WinReform.Gui/ActiveWindows/ActiveWindowsView.xaml
+++ b/src/WinReform/WinReform.Gui/ActiveWindows/ActiveWindowsView.xaml
@@ -75,7 +75,7 @@
                       mah:MultiSelectorHelper.SelectedItems="{Binding SelectedActiveWindows}">
                 <DataGrid.Columns>
                     <DataGridTemplateColumn Header="Application"
-                                            Width="7*"
+                                            Width="8*"
                                             SortMemberPath="Description">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
@@ -97,11 +97,33 @@
                     <DataGridTextColumn Header="PID"
                                         Width="2*"
                                         ElementStyle="{StaticResource DataGridTextColumnTrim}"
-                                        Binding="{Binding Id}" />
-                    <DataGridTextColumn Header="Resolution"
-                                        Width="3*"
+                                        Binding="{Binding Id}">
+                        <DataGridTextColumn.CellStyle>
+                            <Style BasedOn="{StaticResource MahApps.Styles.DataGridCell}" TargetType="DataGridCell">
+                                <Setter Property="ToolTip" Value="The unique identifier assigned to the window"/>
+                            </Style>
+                        </DataGridTextColumn.CellStyle>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Header="Location"
+                                        Width="4*"
                                         ElementStyle="{StaticResource DataGridTextColumnTrim}"
-                                        Binding="{Binding Resolution}" />
+                                        Binding="{Binding Location}">
+                        <DataGridTextColumn.CellStyle>
+                            <Style BasedOn="{StaticResource MahApps.Styles.DataGridCell}" TargetType="DataGridCell">
+                                <Setter Property="ToolTip" Value="The current window location inside the virtual space"/>
+                            </Style>
+                        </DataGridTextColumn.CellStyle>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Header="Resolution"
+                                        Width="4*"
+                                        ElementStyle="{StaticResource DataGridTextColumnTrim}"
+                                        Binding="{Binding Resolution}">
+                        <DataGridTextColumn.CellStyle>
+                            <Style BasedOn="{StaticResource MahApps.Styles.DataGridCell}" TargetType="DataGridCell">
+                                <Setter Property="ToolTip" Value="The current window resolution"/>
+                            </Style>
+                        </DataGridTextColumn.CellStyle>
+                    </DataGridTextColumn>
                 </DataGrid.Columns>
             </DataGrid>
         </Grid>

--- a/src/WinReform/WinReform.Gui/ActiveWindows/ActiveWindowsViewModel.cs
+++ b/src/WinReform/WinReform.Gui/ActiveWindows/ActiveWindowsViewModel.cs
@@ -28,6 +28,15 @@ namespace WinReform.Gui.ActiveWindows
         private bool _autoRefreshActiveWindows;
 
         ///<inheritdoc/>
+        public bool DisplayLocation
+        {
+            get => _displayLocation;
+            set => SetProperty(ref _displayLocation, value);
+        }
+
+        private bool _displayLocation;
+
+        ///<inheritdoc/>
         public ObservableCollection<Domain.Windows.Window> ActiveWindows
         {
             get => _activeWindows;
@@ -170,6 +179,7 @@ namespace WinReform.Gui.ActiveWindows
         {
             if (settings.CurrentSetting != null)
             {
+                DisplayLocation = settings.CurrentSetting.DisplayActiveWindowLocation;
                 _autoRefreshActiveWindows = settings.CurrentSetting.AutoRefreshActiveWindows;
             }
         }

--- a/src/WinReform/WinReform.Gui/ActiveWindows/IActiveWindowsViewModel.cs
+++ b/src/WinReform/WinReform.Gui/ActiveWindows/IActiveWindowsViewModel.cs
@@ -9,6 +9,11 @@ namespace WinReform.Gui.ActiveWindows
     public interface IActiveWindowsViewModel
     {
         /// <summary>
+        /// Gets or Sets an indicates that defines if the location column should be shown
+        /// </summary>
+        bool DisplayLocation { get; set; }
+
+        /// <summary>
         /// Gets or Sets all active windows currently open on the system
         /// </summary>
         ObservableCollection<Domain.Windows.Window> ActiveWindows { get; set; }

--- a/src/WinReform/WinReform.Gui/Infrastructure/Converters/BooleanToVisibilityConverter.cs
+++ b/src/WinReform/WinReform.Gui/Infrastructure/Converters/BooleanToVisibilityConverter.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Text;
 using System.Windows;
 using System.Windows.Data;
 using System.Windows.Markup;

--- a/src/WinReform/WinReform.Gui/Infrastructure/Converters/BooleanToVisibilityConverter.cs
+++ b/src/WinReform/WinReform.Gui/Infrastructure/Converters/BooleanToVisibilityConverter.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using System.Windows;
+using System.Windows.Data;
+using System.Windows.Markup;
+
+namespace WinReform.Gui.Infrastructure.Converters
+{
+    /// <summary>
+    /// Defines a class that converts <see cref="bool"/> to <see cref="Visibility"/>
+    /// </summary>
+    public class BooleanToVisibilityConverter : MarkupExtension, IValueConverter
+    {
+        /// <summary>
+        /// Instance of the <see cref="BooleanToVisibilityConverter"/>
+        /// </summary>
+        private BooleanToVisibilityConverter? _instance;
+
+        /// <summary>
+        /// Provides an instance of the <see cref="BooleanToVisibilityConverter"/>
+        /// </summary>
+        /// <param name="serviceProvider"></param>
+        /// <returns>Returns an instance of the <see cref="BooleanToVisibilityConverter"/></returns>
+        public override object ProvideValue(IServiceProvider serviceProvider) => _instance ?? (_instance = new BooleanToVisibilityConverter());
+
+        /// <summary>
+        /// Convert a <see cref="bool"/> to a <see cref="Visibility"/>
+        /// </summary>
+        public object Convert(object value, Type targetType, object parameter, CultureInfo language)
+        {
+            return (value is bool && (bool)value) ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        /// <summary>
+        /// Converts a <see cref="Visibility"/> to a <see cref="bool"/>
+        /// </summary>
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo language)
+        {
+            return value is Visibility && (Visibility)value == Visibility.Visible;
+        }
+    }
+
+    /// <summary>
+    /// Defines a class that converts <see cref="bool"/> to inverted <see cref="Visibility"/>
+    /// </summary>
+    public class InvertedBooleanToVisibilityConverter : MarkupExtension, IValueConverter
+    {
+        /// <summary>
+        /// Instance of the <see cref="InvertedBooleanToVisibilityConverter"/>
+        /// </summary>
+        private InvertedBooleanToVisibilityConverter? _instance;
+
+        /// <summary>
+        /// Provides an instance of the <see cref="InvertedBooleanToVisibilityConverter"/>
+        /// </summary>
+        /// <param name="serviceProvider"></param>
+        /// <returns>Returns an instance of the <see cref="InvertedBooleanToVisibilityConverter"/></returns>
+        public override object ProvideValue(IServiceProvider serviceProvider) => _instance ?? (_instance = new InvertedBooleanToVisibilityConverter());
+
+        /// <summary>
+        /// Convert a <see cref="bool"/> to a inverted <see cref="Visibility"/>
+        /// </summary>
+        public object Convert(object value, Type targetType, object parameter, CultureInfo language)
+        {
+            return (value is bool && (bool)value) ? Visibility.Collapsed : Visibility.Visible;
+        }
+
+        /// <summary>
+        /// Convert a <see cref="Visibility"/> to a inverted <see cref="bool"/>
+        /// </summary>
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo language)
+        {
+            return value is Visibility && (Visibility)value == Visibility.Collapsed;
+        }
+    }
+}

--- a/src/WinReform/WinReform.Gui/Settings/ApplicationSettingsDesignModel.cs
+++ b/src/WinReform/WinReform.Gui/Settings/ApplicationSettingsDesignModel.cs
@@ -16,7 +16,7 @@
 
         ///<inheritdoc/>
         public bool AutoRefreshActiveWindows { get; set; }
-        
+
         /// <summary>
         /// Create a new instance of the <see cref="ApplicationSettingsDesignModel"/>
         /// </summary>

--- a/src/WinReform/WinReform.Gui/Settings/ApplicationSettingsDesignModel.cs
+++ b/src/WinReform/WinReform.Gui/Settings/ApplicationSettingsDesignModel.cs
@@ -9,19 +9,23 @@
         public bool UseDarkTheme { get; set; }
 
         ///<inheritdoc/>
+        public bool DisplayActiveWindowLocation { get; set; }
+
+        ///<inheritdoc/>
         public bool MinimizeOnClose { get; set; }
 
         ///<inheritdoc/>
         public bool AutoRefreshActiveWindows { get; set; }
-
+        
         /// <summary>
         /// Create a new instance of the <see cref="ApplicationSettingsDesignModel"/>
         /// </summary>
         public ApplicationSettingsDesignModel()
         {
             UseDarkTheme = true;
-            MinimizeOnClose = false;
-            AutoRefreshActiveWindows = true;
+            DisplayActiveWindowLocation = false;
+            MinimizeOnClose = true;
+            AutoRefreshActiveWindows = false;
         }
     }
 }

--- a/src/WinReform/WinReform.Gui/Settings/ApplicationSettingsView.xaml
+++ b/src/WinReform/WinReform.Gui/Settings/ApplicationSettingsView.xaml
@@ -12,21 +12,23 @@
     <!-- Content -->
     <Grid>
         <Grid.RowDefinitions>
-            <RowDefinition Height="auto" />
-            <RowDefinition Height="32" />
-            <RowDefinition Height="auto" />
-            <RowDefinition Height="32" />
-            <RowDefinition Height="32" />
-            <RowDefinition Height="32" />
-            <RowDefinition Height="32" />
+            <RowDefinition Height="auto"/>
+            <RowDefinition Height="auto"/>
         </Grid.RowDefinitions>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="2*" />
-            <ColumnDefinition Width="1*" />
-        </Grid.ColumnDefinitions>
+        
+        <!-- Looks & Feel-->
+        <Grid Grid.Row="0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="2*"/>
+                <ColumnDefinition Width="1*"/>
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="auto"/>
+                <RowDefinition Height="32"/>
+                <RowDefinition Height="32"/>
+            </Grid.RowDefinitions>
 
-        <!-- Looks & Feel -->
-        <TextBlock Grid.Row="0"
+            <TextBlock Grid.Row="0"
                    Grid.Column="0"
                    Grid.ColumnSpan="2"
                    FontSize="18"
@@ -34,20 +36,45 @@
                    Margin="0 5 0 0"
                    Text="Looks &amp; Feel" />
 
-        <TextBlock Grid.Row="1"
+            <TextBlock Grid.Row="1"
                    Grid.Column="0"
                    VerticalAlignment="Center"
                    Margin="8"
                    Text="Dark Theme" />
-        <CheckBox Grid.Row="1"
+            <CheckBox Grid.Row="1"
                   Grid.Column="1"
                   VerticalAlignment="Center"
                   Margin="5"
                   ToolTip="If enabled the application will use a dark theme instead of the default light theme"
                   IsChecked="{Binding UseDarkTheme}" />
+            
+            <TextBlock Grid.Row="2"
+                   Grid.Column="0"
+                   VerticalAlignment="Center"
+                   Margin="8"
+                   Text="Replace PID with Location" />
+            <CheckBox Grid.Row="2"
+                  Grid.Column="1"
+                  VerticalAlignment="Center"
+                  Margin="5"
+                  ToolTip="If enabled the PID column in Active Windows will be repalced with the Location information"
+                  IsChecked="{Binding DisplayActiveWindowLocation}" />
 
-        <!-- Behaviour -->
-        <TextBlock Grid.Row="2"
+        </Grid>
+
+        <!-- Behaviour-->
+        <Grid Grid.Row="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="2*"/>
+                <ColumnDefinition Width="1*"/>
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="auto"/>
+                <RowDefinition Height="32"/>
+                <RowDefinition Height="32"/>
+            </Grid.RowDefinitions>
+
+            <TextBlock Grid.Row="0"
                    Grid.Column="0"
                    Grid.ColumnSpan="2"
                    FontSize="18"
@@ -55,27 +82,29 @@
                    Margin="0 5 0 0"
                    Text="Behaviour" />
 
-        <TextBlock Grid.Row="3"
+            <TextBlock Grid.Row="1"
                    Grid.Column="0"
                    VerticalAlignment="Center"
                    Margin="8"
                    Text="Minimize On Close" />
-        <CheckBox Grid.Row="3"
+            <CheckBox Grid.Row="1"
                   Grid.Column="1"
                   VerticalAlignment="Center"
                   Margin="5"
                   ToolTip="If enabled instead of closing the window will minimize when closed"
                   IsChecked="{Binding MinimizeOnClose}" />
-        <TextBlock Grid.Row="4"
+
+            <TextBlock Grid.Row="2"
                    Grid.Column="0"
                    VerticalAlignment="Center"
                    Margin="8"
                    Text="Auto Refresh Active Windows" />
-        <CheckBox Grid.Row="4"
+            <CheckBox Grid.Row="2"
                   Grid.Column="1"
                   VerticalAlignment="Center"
                   Margin="5"
                   ToolTip="If disabled the active window list and its information won't automatically refresh neither after a change to the window"
                   IsChecked="{Binding AutoRefreshActiveWindows}" />
+        </Grid>
     </Grid>
 </UserControl>

--- a/src/WinReform/WinReform.Gui/Settings/ApplicationSettingsView.xaml
+++ b/src/WinReform/WinReform.Gui/Settings/ApplicationSettingsView.xaml
@@ -12,20 +12,20 @@
     <!-- Content -->
     <Grid>
         <Grid.RowDefinitions>
-            <RowDefinition Height="auto"/>
-            <RowDefinition Height="auto"/>
+            <RowDefinition Height="auto" />
+            <RowDefinition Height="auto" />
         </Grid.RowDefinitions>
-        
+
         <!-- Looks & Feel-->
         <Grid Grid.Row="0">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="2*"/>
-                <ColumnDefinition Width="1*"/>
+                <ColumnDefinition Width="2*" />
+                <ColumnDefinition Width="1*" />
             </Grid.ColumnDefinitions>
             <Grid.RowDefinitions>
-                <RowDefinition Height="auto"/>
-                <RowDefinition Height="32"/>
-                <RowDefinition Height="32"/>
+                <RowDefinition Height="auto" />
+                <RowDefinition Height="32" />
+                <RowDefinition Height="32" />
             </Grid.RowDefinitions>
 
             <TextBlock Grid.Row="0"
@@ -47,7 +47,7 @@
                   Margin="5"
                   ToolTip="If enabled the application will use a dark theme instead of the default light theme"
                   IsChecked="{Binding UseDarkTheme}" />
-            
+
             <TextBlock Grid.Row="2"
                    Grid.Column="0"
                    VerticalAlignment="Center"
@@ -59,19 +59,18 @@
                   Margin="5"
                   ToolTip="If enabled the PID column in Active Windows will be repalced with the Location information"
                   IsChecked="{Binding DisplayActiveWindowLocation}" />
-
         </Grid>
 
         <!-- Behaviour-->
         <Grid Grid.Row="1">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="2*"/>
-                <ColumnDefinition Width="1*"/>
+                <ColumnDefinition Width="2*" />
+                <ColumnDefinition Width="1*" />
             </Grid.ColumnDefinitions>
             <Grid.RowDefinitions>
-                <RowDefinition Height="auto"/>
-                <RowDefinition Height="32"/>
-                <RowDefinition Height="32"/>
+                <RowDefinition Height="auto" />
+                <RowDefinition Height="32" />
+                <RowDefinition Height="32" />
             </Grid.RowDefinitions>
 
             <TextBlock Grid.Row="0"

--- a/src/WinReform/WinReform.Gui/Settings/ApplicationSettingsViewModel.cs
+++ b/src/WinReform/WinReform.Gui/Settings/ApplicationSettingsViewModel.cs
@@ -80,6 +80,7 @@ namespace WinReform.Gui.Settings
 
             // Setup view
             UseDarkTheme = _settings.CurrentSetting.UseDarkTheme;
+            DisplayActiveWindowLocation = _settings.CurrentSetting.DisplayActiveWindowLocation;
             MinimizeOnClose = _settings.CurrentSetting.MinimizeOnClose;
             AutoRefreshActiveWindows = _settings.CurrentSetting.AutoRefreshActiveWindows;
         }

--- a/src/WinReform/WinReform.Gui/Settings/ApplicationSettingsViewModel.cs
+++ b/src/WinReform/WinReform.Gui/Settings/ApplicationSettingsViewModel.cs
@@ -24,6 +24,20 @@ namespace WinReform.Gui.Settings
         private bool _useDarkTheme = true;
 
         ///<inheritdoc/>
+        public bool DisplayActiveWindowLocation
+        {
+            get => _displayActiveWindowLocation;
+            set
+            {
+                SetProperty(ref _displayActiveWindowLocation, value);
+                _settings.CurrentSetting.DisplayActiveWindowLocation = value;
+                SaveSettings();
+            }
+        }
+
+        private bool _displayActiveWindowLocation = false;
+
+        ///<inheritdoc/>
         public bool MinimizeOnClose
         {
             get => _minimizeOnClose;

--- a/src/WinReform/WinReform.Gui/Settings/IApplicationSettingsViewModel.cs
+++ b/src/WinReform/WinReform.Gui/Settings/IApplicationSettingsViewModel.cs
@@ -11,6 +11,11 @@
         bool UseDarkTheme { get; set; }
 
         /// <summary>
+        /// Gets or Sets the state that defines if the Active Windows should display window location instead of PID
+        /// </summary>
+        bool DisplayActiveWindowLocation { get; set; }
+
+        /// <summary>
         /// Gets or Sets the state that defines if the window should be minized when closed
         /// </summary>
         bool MinimizeOnClose { get; set; }

--- a/src/WinReform/WinReform.Gui/Window/MainWindow.xaml
+++ b/src/WinReform/WinReform.Gui/Window/MainWindow.xaml
@@ -88,7 +88,7 @@
                 <ScaleTransform ScaleX="{Binding ElementName=WinReformWindow, Path=ScaleValue}"
                                 ScaleY="{Binding ElementName=WinReformWindow, Path=ScaleValue}" />
             </mah:WindowCommands.LayoutTransform>
-            
+
             <Button Command="{Binding ShowVersionsOnGithubCommand}"
                     ToolTip="Versions on Github">
                 <TextBlock Text="{Binding Version}"


### PR DESCRIPTION
## What does the pull request do?
Add a location column to the Active Windows DataGrid


## What is the current behavior?
Currently the application provides no way to see the current window location


## What is the updated/expected behavior with this PR?
In the settings you can opt to replace the PID with a Location column, now allowing the user to see the active window location within the virtual space


## How was the solution implemented (if it's not obvious)?
n/a


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?

## Breaking changes
SettingStore location has changed to AppData during release, still remains in the execution folder during debug.


## Fixed issues
Fixes #19 
