### PR TITLE
Fixes the minimal size being to small

### DIFF
--- a/src/WinReform/WinReform.Gui/ActiveWindows/ActiveWindowsView.xaml
+++ b/src/WinReform/WinReform.Gui/ActiveWindows/ActiveWindowsView.xaml
@@ -96,7 +96,7 @@
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
                     <DataGridTextColumn Header="PID"
-                                        Width="2*"
+                                        Width="4*"
                                         Visibility="{Binding DataContext.DisplayLocation, Converter={converters:InvertedBooleanToVisibilityConverter}, Source={x:Reference dataContextElement}, Mode=TwoWay}"
                                         ElementStyle="{StaticResource DataGridTextColumnTrim}"
                                         Binding="{Binding Id}">

--- a/src/WinReform/WinReform.Gui/Window/MainWindow.xaml
+++ b/src/WinReform/WinReform.Gui/Window/MainWindow.xaml
@@ -25,9 +25,9 @@
                  UseLayoutRounding="True"
                  WindowStartupLocation="CenterScreen"
                  Closing="MetroWindow_Closing"
-                 Width="{Binding Source={x:Static SystemParameters.PrimaryScreenWidth}, Converter={converters:RatioConverter}, ConverterParameter='0.20'}"
+                 Width="390"
                  MinWidth="315"
-                 Height="{Binding Source={x:Static SystemParameters.PrimaryScreenHeight}, Converter={converters:RatioConverter}, ConverterParameter='0.35'}"
+                 Height="390"
                  MinHeight="315"
                  SizeChanged="WinReformSizeChanged">
 

--- a/src/WinReform/WinReform.Gui/Window/MainWindow.xaml.cs
+++ b/src/WinReform/WinReform.Gui/Window/MainWindow.xaml.cs
@@ -83,7 +83,7 @@ namespace WinReform.Gui
         /// </summary>
         private double CalculateScale()
         {
-            return Math.Min(ActualWidth / 500d, ActualHeight / 400d);
+            return Math.Min(ActualWidth / 390, ActualHeight / 390d);
         }
 
         /// <summary>


### PR DESCRIPTION
## What does the pull request do?
Fixes an issue where with the addition of Location the minimal size would not fully display the Active Window columns


## What is the current behavior?
Currently when Location is enabled the full resolution column isnt shown on the minimal application size


## What is the updated/expected behavior with this PR?
Now everything should fit like expected


## How was the solution implemented (if it's not obvious)?
Ratio's have been removed, and fixed values have been set for width and height, the scaling has been ajusted a bit as well.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?

## Breaking changes
n/a


## Fixed issues
n/a