### PR TITLE
Remove invivible windows from Active Windows

### DIFF
--- a/src/Tests/WinReform.Domain.Tests/Windows/WindowServiceTests.cs
+++ b/src/Tests/WinReform.Domain.Tests/Windows/WindowServiceTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Moq;
 using WinReform.Domain.Process;
 using WinReform.Domain.WinApi;
@@ -166,6 +167,7 @@ namespace WinReform.Domain.Tests.Windows
             var winApiServiceMock = new Mock<IWinApiService>();
             var processServiceMock = new Mock<IProcessService>();
 
+            winApiServiceMock.Setup(x => x.GetWindowRect(It.IsAny<IntPtr>())).Returns(new Rect(10, 20, 30, 40));
             processServiceMock.Setup(x => x.GetActiveProcesses()).Returns(_windowProcessList);
 
             var windowService = new WindowService(winApiServiceMock.Object, processServiceMock.Object);

--- a/src/Tests/WinReform.Domain.Tests/Windows/WindowServiceTests.cs
+++ b/src/Tests/WinReform.Domain.Tests/Windows/WindowServiceTests.cs
@@ -180,6 +180,25 @@ namespace WinReform.Domain.Tests.Windows
             Assert.NotNull(result.FirstOrDefault()?.WindowHandle);
         }
 
+        [Fact]
+        public void GetActiveWindows_ProcessesWithWindowsButNoDimensions_ShouldReturnEmptyList()
+        {
+            // Prepare
+            var winApiServiceMock = new Mock<IWinApiService>();
+            var processServiceMock = new Mock<IProcessService>();
+
+            winApiServiceMock.Setup(x => x.GetWindowRect(It.IsAny<IntPtr>())).Returns(new Rect(0, 0, 0, 0));
+            processServiceMock.Setup(x => x.GetActiveProcesses()).Returns(_windowProcessList);
+
+            var windowService = new WindowService(winApiServiceMock.Object, processServiceMock.Object);
+
+            // Act
+            var result = windowService.GetActiveWindows();
+
+            // Assert
+            Assert.Equal(new List<Window>(), result);
+        }
+
         #endregion GetActiveWindows Tests
 
         #region ResizeWindow Tests

--- a/src/WinReform/WinReform.Domain/Windows/WindowService.cs
+++ b/src/WinReform/WinReform.Domain/Windows/WindowService.cs
@@ -49,13 +49,19 @@ namespace WinReform.Domain.Windows
                         continue; // Process doesn't own a window
                     }
 
+                    var dimensions = _winApiService.GetWindowRect(process.MainWindowHandle);
+                    if(dimensions.IsEmpty)
+                    {
+                        continue; // Has a 0 by 0 window, and not meant to display
+                    }
+
                     windows.Add(new Window()
                     {
                         Id = process.Id,
                         WindowHandle = process.MainWindowHandle,
                         Description = process.MainModule?.FileVersionInfo.FileDescription ?? string.Empty,
                         Icon = Icon.ExtractAssociatedIcon(process.MainModule?.FileName).ToBitmap(),
-                        Dimensions = _winApiService.GetWindowRect(process.MainWindowHandle)
+                        Dimensions = dimensions
                     });
                 }
                 catch (Win32Exception)


### PR DESCRIPTION
## What does the pull request do?
Fixes an issue where windows that contain a window thats invivible (with 0 by 0 resoltuion) are removed from the Active Windows list


## What is the current behavior?
Currently the Active Windows list might contain windows that don't contain a resolution


## What is the updated/expected behavior with this PR?
Windows that have no resolution are now filrered out form the active window list


## How was the solution implemented (if it's not obvious)?
We now do a simple IsEmpty check on the dimensions before adding it


## Checklist

- [x] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?

## Breaking changes
n/a


## Fixed issues
Fixes #38 
