### PR TITLE
Fixes Null Reference exception on application close

### DIFF
--- a/src/WinReform/WinReform/ActiveWindows/ActiveWindowsViewModel.cs
+++ b/src/WinReform/WinReform/ActiveWindows/ActiveWindowsViewModel.cs
@@ -157,7 +157,7 @@ namespace WinReform.ActiveWindows
             Task.Run(() =>
             {
                 var result = _windowService.GetActiveWindows().ToList();
-                Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Background, new Action(() => ActiveWindows.UpdateCollection(result)));
+                Application.Current?.Dispatcher.BeginInvoke(DispatcherPriority.Background, new Action(() => ActiveWindows.UpdateCollection(result)));
             });
         }
 


### PR DESCRIPTION
## What does the pull request do?
Fixes an issue where when closing the application right when the RefreshActiveWindows is triggered, could cause it to throw just before the process has fully ended.


## What is the current behavior?
An exception might be thrown just before the application closes.


## What is the updated/expected behavior with this PR?
Handles the disposed application gracefully


## How was the solution implemented (if it's not obvious)?
By adding a null check


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?

## Breaking changes
N/A


## Fixed issues
N/A