### PR TITLE
Allow for 0x0 windows in window process list

### DIFF
--- a/src/Tests/WinReform.Tests/ActiveWindows/ActiveWindowsViewModelTests.cs
+++ b/src/Tests/WinReform.Tests/ActiveWindows/ActiveWindowsViewModelTests.cs
@@ -99,7 +99,7 @@ namespace WinReform.Tests.ActiveWindows
             viewmodel.RefreshActiveWindows();
 
             // Assert
-            windowServiceMock.Verify(x => x.GetActiveWindows(), Times.AtLeastOnce());
+            windowServiceMock.Verify(x => x.GetActiveWindows(It.IsAny<bool>()), Times.AtLeastOnce());
         }
 
         #endregion RefreshActiveWindows tests

--- a/src/WinReform/WinReform.Domain/Settings/ApplicationSettings.cs
+++ b/src/WinReform/WinReform.Domain/Settings/ApplicationSettings.cs
@@ -28,5 +28,11 @@
         /// <remarks>Defaults to <see langword="true"/></remarks>
         /// </summary>
         public bool AutoRefreshActiveWindows { get; set; } = true;
+
+        /// <summary>
+        /// Gets or Sets an indicator that defines if processes with 0x0 windows should be displayed.
+        /// <remarks>Defaults to <see langword="false"/></remarks>
+        /// </summary>
+        public bool ShowZeroSizeWindows { get; set; } = false;
     }
 }

--- a/src/WinReform/WinReform.Domain/Windows/IWindowService.cs
+++ b/src/WinReform/WinReform.Domain/Windows/IWindowService.cs
@@ -9,10 +9,11 @@ namespace WinReform.Domain.Windows
     public interface IWindowService
     {
         /// <summary>
-        /// Gets the ative windows running on the system
+        /// Gets the active windows running on the system, with optional filtering for processes without windows and zero-size windows.
         /// </summary>
-        /// <returns>Returns <see cref="IEnumerable{Window}"/> containing all active windows on the system</returns>
-        IEnumerable<Window> GetActiveWindows();
+        /// <param name="showZeroSizeWindows">If <see langword="true"/>, includes windows with a size of 0x0. Defaults to <see langword="false"/>.</param>
+        /// <returns>Returns an <see cref="IEnumerable{Window}"/> containing all active windows on the system, based on the applied filters.</returns>
+        IEnumerable<Window> GetActiveWindows(bool showZeroSizeWindows = false);
 
         /// <summary>
         /// Resize a window

--- a/src/WinReform/WinReform.Domain/Windows/WindowService.cs
+++ b/src/WinReform/WinReform.Domain/Windows/WindowService.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
+﻿using System.ComponentModel;
+using System.Diagnostics;
 using System.Drawing;
-using System.Linq;
 using WinReform.Domain.Process;
 using WinReform.Domain.WinApi;
 using WinReform.Domain.WinApi.Types;
@@ -36,7 +34,7 @@ namespace WinReform.Domain.Windows
         }
 
         /// <inheritdoc/>
-        public IEnumerable<Window> GetActiveWindows()
+        public IEnumerable<Window> GetActiveWindows(bool showZeroSizeWindows = false)
         {
             var windows = new List<Window>();
 
@@ -44,24 +42,29 @@ namespace WinReform.Domain.Windows
             {
                 try
                 {
-                    if (process.MainWindowHandle == IntPtr.Zero)
+                    // Ensure the process has a valid window
+                    if (process.MainWindowHandle == IntPtr.Zero || process.HasExited)
                     {
-                        continue; // Process doesn't own a window
+                        continue; // Skip processes that do not have a window
                     }
 
                     var dimensions = _winApiService.GetWindowRect(process.MainWindowHandle);
-                    if (dimensions.IsEmpty)
+                    var isZeroSize = dimensions.IsEmpty;
+                    if (isZeroSize && !showZeroSizeWindows)
                     {
-                        continue; // Has a 0 by 0 window, and not meant to display
+                        continue; // Skip windows with 0x0 size
                     }
 
-                    Bitmap? iconBitmap = default;
-                    if (process.MainModule?.FileName != null && File.Exists(process.MainModule.FileName))
+                    var description = string.Empty;
+                    Bitmap? iconBitmap = null;
+                    if (CanAccessProcess(process))
                     {
-                        var icon = Icon.ExtractAssociatedIcon(process.MainModule.FileName);
-                        if (icon != null)
+                        description = process.MainModule?.FileVersionInfo?.FileDescription ?? string.Empty;
+
+                        if (File.Exists(process.MainModule?.FileName))
                         {
-                            iconBitmap = icon.ToBitmap();
+                            var icon = Icon.ExtractAssociatedIcon(process.MainModule.FileName);
+                            iconBitmap = icon?.ToBitmap();
                         }
                     }
 
@@ -69,18 +72,47 @@ namespace WinReform.Domain.Windows
                     {
                         Id = process.Id,
                         WindowHandle = process.MainWindowHandle,
-                        Description = process.MainModule?.FileVersionInfo.FileDescription ?? string.Empty,
+                        Description = description,
                         Icon = iconBitmap,
                         Dimensions = dimensions
                     });
                 }
-                catch (Win32Exception)
+                catch (Exception ex)
                 {
-                    // Do nothing
+                    Debug.WriteLine($"Error processing process {process.ProcessName}: {ex.Message}");
                 }
             }
 
             return windows.OrderBy(w => w.Description).ToList();
+        }
+
+        /// <summary>
+        /// Determines whether the specified process is accessible by checking if its <see cref="Process.MainModule"/> can be read.
+        /// </summary>
+        /// <param name="process">The <see cref="Process"/> to check for accessibility.</param>
+        /// <returns>
+        /// <see langword="true"/> if the process is accessible and its modules can be read; otherwise, <see langword="false"/>.
+        /// </returns>
+        /// <remarks>
+        /// Some system or protected processes restrict access to their module information,
+        /// which can cause exceptions. This method prevents unnecessary exceptions
+        /// by safely checking access permissions before retrieving process details.
+        /// </remarks>
+        private static bool CanAccessProcess(System.Diagnostics.Process process)
+        {
+            try
+            {
+                _ = process.MainModule;
+                return true;
+            }
+            catch (Win32Exception)
+            {
+                return false; // Process is protected or restricted
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return false; // Process access is denied
+            }
         }
 
         /// <inheritdoc/>

--- a/src/WinReform/WinReform/ActiveWindows/ActiveWindowsViewModel.cs
+++ b/src/WinReform/WinReform/ActiveWindows/ActiveWindowsViewModel.cs
@@ -24,6 +24,11 @@ namespace WinReform.ActiveWindows
         /// </summary>
         private bool _autoRefreshActiveWindows;
 
+        /// <summary>
+        /// State that defines if processes with 0x0 size windows should be displayed in the Active Windows list
+        /// </summary>
+        private bool _showZeroSizeWindows;
+
         ///<inheritdoc/>
         public bool DisplayLocation
         {
@@ -128,7 +133,7 @@ namespace WinReform.ActiveWindows
             // Setup view
             ApplicationSettingsChanged(applicationSettings);
             SelectedActiveWindows.CollectionChanged += SelectedActiveWindowsChanged;
-            ActiveWindows.UpdateCollection(_windowService.GetActiveWindows().ToList());
+            ActiveWindows.UpdateCollection(_windowService.GetActiveWindows(_showZeroSizeWindows).ToList());
         }
 
         /// <summary>
@@ -156,7 +161,7 @@ namespace WinReform.ActiveWindows
         {
             Task.Run(() =>
             {
-                var result = _windowService.GetActiveWindows().ToList();
+                var result = _windowService.GetActiveWindows(_showZeroSizeWindows).ToList();
                 Application.Current?.Dispatcher.BeginInvoke(DispatcherPriority.Background, new Action(() => ActiveWindows.UpdateCollection(result)));
             });
         }
@@ -187,6 +192,7 @@ namespace WinReform.ActiveWindows
             {
                 DisplayLocation = settings.CurrentSetting.DisplayActiveWindowLocation;
                 _autoRefreshActiveWindows = settings.CurrentSetting.AutoRefreshActiveWindows;
+                _showZeroSizeWindows = settings.CurrentSetting.ShowZeroSizeWindows;
             }
         }
 

--- a/src/WinReform/WinReform/Settings/ApplicationSettingsDesignModel.cs
+++ b/src/WinReform/WinReform/Settings/ApplicationSettingsDesignModel.cs
@@ -17,6 +17,9 @@
         ///<inheritdoc/>
         public bool AutoRefreshActiveWindows { get; set; }
 
+        ///<inheritdoc/>
+        public bool ShowZeroSizeWindows { get; set; }
+
         /// <summary>
         /// Create a new instance of the <see cref="ApplicationSettingsDesignModel"/>
         /// </summary>
@@ -26,6 +29,7 @@
             DisplayActiveWindowLocation = false;
             MinimizeOnClose = true;
             AutoRefreshActiveWindows = false;
+            ShowZeroSizeWindows = false;
         }
     }
 }

--- a/src/WinReform/WinReform/Settings/ApplicationSettingsView.xaml
+++ b/src/WinReform/WinReform/Settings/ApplicationSettingsView.xaml
@@ -1,8 +1,8 @@
 ﻿<UserControl x:Class="WinReform.Settings.ApplicationSettingsView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:viewModel="clr-namespace:WinReform.Infrastructure.Common.ViewModel"
              xmlns:local="clr-namespace:WinReform.Settings"
              mc:Ignorable="d"
@@ -24,6 +24,7 @@
             </Grid.ColumnDefinitions>
             <Grid.RowDefinitions>
                 <RowDefinition Height="auto" />
+                <RowDefinition Height="32" />
                 <RowDefinition Height="32" />
                 <RowDefinition Height="32" />
             </Grid.RowDefinitions>
@@ -59,6 +60,18 @@
                   Margin="5"
                   ToolTip="If enabled the PID column in Active Windows will be repalced with the Location information"
                   IsChecked="{Binding DisplayActiveWindowLocation}" />
+
+            <TextBlock Grid.Row="4"
+                   Grid.Column="0"
+                   VerticalAlignment="Center"
+                   Margin="8"
+                   Text="Show 0x0 Size Windows" />
+            <CheckBox Grid.Row="4"
+                  Grid.Column="1"
+                  VerticalAlignment="Center"
+                  Margin="5"
+                  ToolTip="If enabled, windows with a size of 0x0 will be displayed in the Active Windows list"
+                  IsChecked="{Binding ShowZeroSizeWindows}" />
         </Grid>
 
         <!-- Behaviour-->

--- a/src/WinReform/WinReform/Settings/ApplicationSettingsViewModel.cs
+++ b/src/WinReform/WinReform/Settings/ApplicationSettingsViewModel.cs
@@ -65,6 +65,20 @@ namespace WinReform.Settings
 
         private bool _autoRefreshActiveWindows;
 
+        ///<inheritdoc/>
+        public bool ShowZeroSizeWindows
+        {
+            get => _showZeroSizeWindows;
+            set
+            {
+                SetProperty(ref _showZeroSizeWindows, value);
+                _settings.CurrentSetting.ShowZeroSizeWindows = value;
+                SaveSettings();
+            }
+        }
+
+        private bool _showZeroSizeWindows;
+
         /// <summary>
         /// <see cref="ISetting{TSetting}"/> containing the <see cref="ApplicationSettings"/>
         /// </summary>
@@ -83,6 +97,7 @@ namespace WinReform.Settings
             DisplayActiveWindowLocation = _settings.CurrentSetting.DisplayActiveWindowLocation;
             MinimizeOnClose = _settings.CurrentSetting.MinimizeOnClose;
             AutoRefreshActiveWindows = _settings.CurrentSetting.AutoRefreshActiveWindows;
+            ShowZeroSizeWindows = _settings.CurrentSetting.ShowZeroSizeWindows;
         }
 
         /// <summary>

--- a/src/WinReform/WinReform/Settings/IApplicationSettingsViewModel.cs
+++ b/src/WinReform/WinReform/Settings/IApplicationSettingsViewModel.cs
@@ -24,5 +24,10 @@
         /// Gets or Sets the state that defines if the Active Windows should automaticly be refreshed
         /// </summary>
         bool AutoRefreshActiveWindows { get; set; }
+
+        /// <summary>
+        /// Gets or Sets the state that defines if processes with 0x0 size windows should be displayed
+        /// </summary>
+        bool ShowZeroSizeWindows { get; set; }
     }
 }


### PR DESCRIPTION
## What does the pull request do?
Adds a new settings that allow the inclusion of 0x0 windows in the window process list


## What is the current behavior?
These types of windows are filtered out


## What is the updated/expected behavior with this PR?
By default, the behaviour should be the same as previously, but with the setting enabled, any window with a size of 0x0 will also become available in the window process list.

## How was the solution implemented (if it's not obvious)?
N/A

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?

## Breaking changes
N/A


## Fixed issues
N/A