### PR TITLE
Added Selected Window Overlay

### DIFF
--- a/src/WinReform.sln
+++ b/src/WinReform.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29905.134
+# Visual Studio Version 17
+VisualStudioVersion = 17.13.35825.156 d17.13
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{18F70F40-E8C4-46D7-8FF7-0DFA19A71723}"
 	ProjectSection(SolutionItems) = preProject

--- a/src/WinReform/WinReform.Domain/Settings/ApplicationSettings.cs
+++ b/src/WinReform/WinReform.Domain/Settings/ApplicationSettings.cs
@@ -34,5 +34,11 @@
         /// <remarks>Defaults to <see langword="false"/></remarks>
         /// </summary>
         public bool ShowZeroSizeWindows { get; set; } = false;
+
+        /// <summary>
+        /// Gets or Sets an indicator that defines if a overlay should be rendered on topof selected windows
+        /// <remarks>Defaults to <see langword="false"/></remarks>
+        /// </summary>
+        public bool HighlightSelectedWindows { get; set; } = false;
     }
 }

--- a/src/WinReform/WinReform.Domain/WinApi/IWinApiService.cs
+++ b/src/WinReform/WinReform.Domain/WinApi/IWinApiService.cs
@@ -51,5 +51,12 @@ namespace WinReform.Domain.WinApi
         /// </summary>
         /// <returns>Returns <see cref="List{Monitor}"/> of all the monitors available</returns>
         List<Monitor> GetAllMonitors();
+
+        /// <summary>
+        /// Retrieves the window title for the specified process.
+        /// </summary>
+        /// <param name="windowHandle">handle of the window to get the title for.</param>
+        /// <returns>The window title if available, otherwise an empty string.</returns>
+        string GetWindowTitle(IntPtr windowHandle);
     }
 }

--- a/src/WinReform/WinReform.Domain/WinApi/IWinApiService.cs
+++ b/src/WinReform/WinReform.Domain/WinApi/IWinApiService.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
-namespace WinReform.Domain.WinApi
+﻿namespace WinReform.Domain.WinApi
 {
     /// <summary>
     /// Represents a class that acts as a service that allows for the execution of unmanaged code
@@ -20,6 +17,13 @@ namespace WinReform.Domain.WinApi
         /// <param name="hwnd"><see cref="IntPtr"/> containing the handle of the window to get the <see cref="Rect"/> of</param>
         /// <returns>Returns <see cref="Rect"/> containing the dimensions of the given window</returns>
         Rect GetWindowRect(IntPtr hwnd);
+
+        /// <summary>
+        /// Gets the real visible bounds of a window (excluding invisible borders).
+        /// </summary>
+        /// <param name="hwnd">Handle to the window.</param>
+        /// <returns>A <see cref="Rect"/> containing the window's actual visible dimensions.</returns>
+        Rect GetVisibleWindowRect(IntPtr hwnd);
 
         /// <summary>
         /// Sets a new position for a given window
@@ -53,10 +57,24 @@ namespace WinReform.Domain.WinApi
         List<Monitor> GetAllMonitors();
 
         /// <summary>
-        /// Retrieves the window title for the specified process.
+        /// Retrieves the title of the specified window.
         /// </summary>
-        /// <param name="windowHandle">handle of the window to get the title for.</param>
-        /// <returns>The window title if available, otherwise an empty string.</returns>
+        /// <param name="windowHandle">The handle of the window whose title is to be retrieved.</param>
+        /// <returns>The window title if available; otherwise, an empty string.</returns>
         string GetWindowTitle(IntPtr windowHandle);
+
+        /// <summary>
+        /// Registers a hook to monitor when a specific window moves.
+        /// </summary>
+        /// <param name="windowHandle">The handle of the window to track.</param>
+        /// <param name="callback">The action to invoke when the window moves.</param>
+        /// <returns>An <see cref="IntPtr"/> representing the event hook handle.</returns>
+        IntPtr RegisterWindowMoveHook(IntPtr windowHandle, Action callback);
+
+        /// <summary>
+        /// Unregisters a previously registered window move event hook, stopping movement tracking.
+        /// </summary>
+        /// <param name="hookHandle">The handle of the event hook to be removed.</param>
+        void UnregisterWindowMoveHook(IntPtr hookHandle);
     }
 }

--- a/src/WinReform/WinReform.Domain/WinApi/Types/DwmWindowAttributeType.cs
+++ b/src/WinReform/WinReform.Domain/WinApi/Types/DwmWindowAttributeType.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WinReform.Domain.WinApi.Types
+{
+    /// <summary>
+    /// Defines attributes for window properties retrieved using
+    /// <see href="https://learn.microsoft.com/en-us/windows/win32/api/dwmapi/nf-dwmapi-dwmgetwindowattribute">DwmGetWindowAttribute</see>.
+    /// </summary>
+    public enum DwmWindowAttributeType
+    {
+        /// <summary>
+        /// Retrieves the visible window bounds, excluding invisible borders and shadows.
+        /// </summary>
+        ExtendedFrameBounds = 9,
+
+        /// <summary>
+        /// Retrieves the non-client rendering policy for the window.
+        /// </summary>
+        NonClientRenderingPolicy = 2,
+
+        /// <summary>
+        /// Retrieves whether non-client rendering is enabled.
+        /// </summary>
+        NonClientRenderingEnabled = 1,
+
+        /// <summary>
+        /// Retrieves the caption button bounds.
+        /// </summary>
+        CaptionButtonBounds = 5,
+
+        /// <summary>
+        /// Retrieves whether the window is cloaked (hidden for rendering purposes).
+        /// </summary>
+        Cloaked = 14,
+
+        /// <summary>
+        /// Retrieves the cloaking reasons for a window (if any).
+        /// </summary>
+        CloakReason = 15,
+
+        /// <summary>
+        /// Retrieves the DWM transition duration override.
+        /// </summary>
+        TransitionDurationOverride = 20,
+
+        /// <summary>
+        /// Retrieves whether the window has a non-client area that should be rendered.
+        /// </summary>
+        HasIconicBitmap = 10,
+
+        /// <summary>
+        /// Retrieves whether the window should be treated as a force iconic representation.
+        /// </summary>
+        ForceIconicRepresentation = 7,
+
+        /// <summary>
+        /// Retrieves the flip 3D policy for the window.
+        /// </summary>
+        Flip3DPolicy = 8,
+
+        /// <summary>
+        /// Retrieves whether DWM transitions are disabled.
+        /// </summary>
+        DisallowTransitions = 17,
+
+        /// <summary>
+        /// Retrieves the last active frame bounds.
+        /// </summary>
+        LastActiveFrameBounds = 16,
+
+        /// <summary>
+        /// Retrieves the window’s DWM-rendered thumbnail icon.
+        /// </summary>
+        ThumbnailIcon = 19,
+
+        /// <summary>
+        /// Retrieves the force disable transitions flag.
+        /// </summary>
+        ForceDisableTransitions = 18,
+
+        /// <summary>
+        /// Retrieves the width of the borders that DWM extends around a window.
+        /// </summary>
+        BorderWidth = 13
+    }
+}

--- a/src/WinReform/WinReform.Domain/WinApi/Types/ExWsStyleType.cs
+++ b/src/WinReform/WinReform.Domain/WinApi/Types/ExWsStyleType.cs
@@ -1,0 +1,71 @@
+﻿namespace WinReform.Domain.WinApi.Types
+{
+    /// <summary>
+    /// Defines a class that represents all possible extended window styles (ExStyle) for the Get and Set WindowLongPtr method.
+    /// <a href="https://docs.microsoft.com/en-us/windows/win32/winmsg/extended-window-styles">List of ExStyle values</a>
+    /// </summary>
+    [Flags]
+    public enum ExWsStyleType : uint
+    {
+        /// <summary>
+        /// The window accepts drag-and-drop files.
+        /// </summary>
+        AcceptFiles = 0x00000010,
+
+        /// <summary>
+        /// The window should be placed above all non-topmost windows.
+        /// </summary>
+        AppWindow = 0x00040000,
+
+        /// <summary>
+        /// The window has a border with a raised edge.
+        /// </summary>
+        ClientEdge = 0x00000200,
+
+        /// <summary>
+        /// The window contains child windows that should be clipped relative to the parent.
+        /// </summary>
+        Composited = 0x02000000,
+
+        /// <summary>
+        /// The window is a layered window.
+        /// NOTE: Required for transparency effects.
+        /// </summary>
+        Layered = 0x00080000,
+
+        /// <summary>
+        /// The window does not pass its window region to a child window.
+        /// </summary>
+        NoInheritLayout = 0x00100000,
+
+        /// <summary>
+        /// The window does not repaint its contents when moved.
+        /// </summary>
+        NoActivate = 0x08000000,
+
+        /// <summary>
+        /// The window should be placed above all non-topmost windows.
+        /// </summary>
+        NoParentNotify = 0x00000004,
+
+        /// <summary>
+        /// The window has a static edge appearance.
+        /// </summary>
+        StaticEdge = 0x00020000,
+
+        /// <summary>
+        /// The window is a topmost window.
+        /// </summary>
+        TopMost = 0x00000008,
+
+        /// <summary>
+        /// The window is transparent to hit testing, allowing mouse events to pass through.
+        /// </summary>
+        Transparent = 0x00000020,
+
+        /// <summary>
+        /// The window has a sunken border.
+        /// </summary>
+        WindowEdge = 0x00000100,
+    }
+}

--- a/src/WinReform/WinReform.Domain/WinApi/Types/HResultType.cs
+++ b/src/WinReform/WinReform.Domain/WinApi/Types/HResultType.cs
@@ -94,6 +94,11 @@
         OutOfMemory = 0x8007000E,
 
         /// <summary>
+        /// The specified window handle is invalid
+        /// </summary>
+        InvalidWindowHandle = 0x80070578,
+
+        /// <summary>
         /// One or more arguments are invalid
         /// </summary>
         InvalidArguments = 0x80070057,

--- a/src/WinReform/WinReform.Domain/WinApi/WinApiService.cs
+++ b/src/WinReform/WinReform.Domain/WinApi/WinApiService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace WinReform.Domain.WinApi
 {
@@ -173,6 +174,34 @@ namespace WinReform.Domain.WinApi
             EnumDisplayMonitors(IntPtr.Zero, IntPtr.Zero, Callback, IntPtr.Zero);
 
             return monitors;
+        }
+
+        /// <summary>
+        /// Retrieves the title bar text of a specified window.
+        /// </summary>
+        /// <param name="hWnd">Handle to the window.</param>
+        /// <param name="lpString">Buffer to receive the title text.</param>
+        /// <param name="nMaxCount">Maximum number of characters to copy, including null terminator.</param>
+        /// <returns>Length of the copied string (excluding null terminator), or 0 if the window has no title.</returns>
+        /// <see href="https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getwindowtext"/>
+        [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+        private static extern int GetWindowText(IntPtr hWnd, StringBuilder lpString, int nMaxCount);
+
+        /// <inheritdoc/>
+        public string GetWindowTitle(IntPtr windowHandle)
+        {
+            const int nChars = 256;
+            var buffer = new StringBuilder(256);
+
+            if (windowHandle != IntPtr.Zero)
+            {
+                if (GetWindowText(windowHandle, buffer, nChars) > 0)
+                {
+                    return buffer.ToString();
+                }
+            }
+
+            return string.Empty;
         }
     }
 }

--- a/src/WinReform/WinReform.Domain/WinApi/WinApiService.cs
+++ b/src/WinReform/WinReform.Domain/WinApi/WinApiService.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Text;
+using WinReform.Domain.WinApi.Types;
 
 namespace WinReform.Domain.WinApi
 {
@@ -202,6 +203,110 @@ namespace WinReform.Domain.WinApi
             }
 
             return string.Empty;
+        }
+
+        /// <summary>
+        /// Hooks into Windows events to track window position changes.
+        /// <a href="https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setwineventhook">SetWinEventHook</a>
+        /// </summary>
+        /// <param name="eventMin">The lowest event value to track.</param>
+        /// <param name="eventMax">The highest event value to track.</param>
+        /// <param name="hmodWinEventProc">Handle to the DLL containing the event hook function (null for inline).</param>
+        /// <param name="lpfnWinEventProc">The callback function to be called when an event is triggered.</param>
+        /// <param name="idProcess">The process ID to track (0 for all processes).</param>
+        /// <param name="idThread">The thread ID to track (0 for all threads).</param>
+        /// <param name="dwFlags">Flags to control event hook behavior.</param>
+        /// <returns>A handle to the event hook.</returns>
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern IntPtr SetWinEventHook(uint eventMin, uint eventMax, IntPtr hmodWinEventProc, WinEventDelegate lpfnWinEventProc, uint idProcess, uint idThread, uint dwFlags);
+
+        /// <summary>
+        /// Removes a previously registered event hook.
+        /// <a href="https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-unhookwinevent">UnhookWinEvent</a>
+        /// </summary>
+        /// <param name="hWinEventHook">Handle to the event hook to be removed.</param>
+        /// <returns><see langword="true"/> if the hook was successfully removed, otherwise <see langword="false"/>.</returns>
+        [DllImport("user32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool UnhookWinEvent(IntPtr hWinEventHook);
+
+        /// <summary>
+        /// Stores active window event hooks to prevent garbage collection.
+        /// This ensures that callbacks remain valid for the lifetime of the hook.
+        /// </summary>
+        private static readonly Dictionary<IntPtr, WinEventDelegate> _eventHooks = new();
+
+        /// <summary>
+        /// Delegate for handling Windows event hook callbacks.
+        /// This is used to receive notifications when specific window events occur,
+        /// such as window position changes.
+        /// </summary>
+        /// <param name="hWinEventHook">Handle to the event hook.</param>
+        /// <param name="eventType">The type of event that was triggered.</param>
+        /// <param name="hwnd">The handle to the window associated with the event.</param>
+        /// <param name="idObject">The object identifier for the event.</param>
+        /// <param name="idChild">The child identifier of the event target.</param>
+        /// <param name="dwEventThread">The thread ID where the event was generated.</param>
+        /// <param name="dwmsEventTime">The timestamp of the event, in milliseconds.</param>
+        private delegate void WinEventDelegate(IntPtr hWinEventHook, uint eventType, IntPtr hwnd, int idObject, int idChild, uint dwEventThread, uint dwmsEventTime);
+
+        /// <inheritdoc/>
+        public IntPtr RegisterWindowMoveHook(IntPtr windowHandle, Action callback)
+        {
+            var winEventCallback = new WinEventDelegate((hWinEventHook, eventType, hwnd, idObject, idChild, dwEventThread, dwmsEventTime) =>
+            {
+                if (hwnd == windowHandle)
+                {
+                    callback();
+                }
+            });
+
+            var hookHandle = SetWinEventHook(0x800B, 0x800B, IntPtr.Zero, winEventCallback, 0, 0, 0);
+            if (hookHandle != IntPtr.Zero)
+            {
+                _eventHooks[hookHandle] = winEventCallback;
+            }
+
+            return hookHandle;
+        }
+
+        /// <inheritdoc/>
+        public void UnregisterWindowMoveHook(IntPtr hookHandle)
+        {
+            if (hookHandle != IntPtr.Zero)
+            {
+                UnhookWinEvent(hookHandle);
+                _eventHooks.Remove(hookHandle);
+            }
+        }
+
+        /// <summary>
+        /// Retrieves the extended frame bounds of a window, excluding non-client areas.
+        /// <a href="https://learn.microsoft.com/en-us/windows/win32/api/dwmapi/nf-dwmapi-dwmgetwindowattribute">DwmGetWindowAttribute</a>
+        /// </summary>
+        /// <param name="hwnd">Handle to the window.</param>
+        /// <param name="dwAttribute">The attribute to retrieve (e.g., DWMWA_EXTENDED_FRAME_BOUNDS).</param>
+        /// <param name="pvAttribute">Receives the attribute value.</param>
+        /// <param name="cbAttribute">Size of the output buffer.</param>
+        /// <returns>0 if successful, otherwise a Win32 error code.</returns>
+        [DllImport("dwmapi.dll", EntryPoint = "DwmGetWindowAttribute", PreserveSig = true)]
+        private static extern int DwmGetWindowAttribute(IntPtr hwnd, int dwAttribute, out Rect pvAttribute, int cbAttribute);
+
+        /// <inheritdoc/>
+        public Rect GetVisibleWindowRect(IntPtr hwnd)
+        {
+            if (hwnd == IntPtr.Zero)
+            {
+                throw new ArgumentException("Invalid window handle.", nameof(hwnd));
+            }
+
+            var result = DwmGetWindowAttribute(hwnd, (int)DwmWindowAttributeType.ExtendedFrameBounds, out var rect, Marshal.SizeOf(typeof(Rect)));
+            if (result != 0)
+            {
+                throw new InvalidOperationException($"DwmGetWindowAttribute failed with error code {result}");
+            }
+
+            return rect;
         }
     }
 }

--- a/src/WinReform/WinReform.Domain/Windows/IWindowService.cs
+++ b/src/WinReform/WinReform.Domain/Windows/IWindowService.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+﻿using System.Drawing.Drawing2D;
 using WinReform.Domain.WinApi;
 
 namespace WinReform.Domain.Windows
@@ -14,6 +14,13 @@ namespace WinReform.Domain.Windows
         /// <param name="showZeroSizeWindows">If <see langword="true"/>, includes windows with a size of 0x0. Defaults to <see langword="false"/>.</param>
         /// <returns>Returns an <see cref="IEnumerable{Window}"/> containing all active windows on the system, based on the applied filters.</returns>
         IEnumerable<Window> GetActiveWindows(bool showZeroSizeWindows = false);
+
+        /// <summary>
+        /// Updates a given window with the latest dimensions
+        /// </summary>
+        /// <param name="window">The <see cref="Window"/> to fetch updated dimensions for.</param>
+        /// <returns>A new <see cref="Window"/> instance with updated dimensions.</returns>
+        Window UpdateWindow(Window window);
 
         /// <summary>
         /// Resize a window
@@ -41,5 +48,32 @@ namespace WinReform.Domain.Windows
         /// </summary>
         /// <param name="window"><see cref="Window"/> to be redrawn</param>
         void RedrawWindow(Window window);
+
+        /// <summary>
+        /// Hooks into the Windows event system to track when a specific window moves.
+        /// </summary>
+        /// <param name="targetWindow">The <see cref="Window"/> whose movement should be tracked.</param>
+        /// <param name="callback">The action to invoke when the window moves.</param>
+        void HookWindowMoveEvent(Window targetWindow, Action callback);
+
+        /// <summary>
+        /// Unhooks a previously registered window move event, stopping movement tracking for the specified window.
+        /// </summary>
+        /// <param name="targetWindow">The <see cref="Window"/> whose movement tracking should be removed.</param>
+        void UnhookWindowMoveEvent(Window targetWindow);
+
+        /// <summary>
+        /// Enables click-through behavior for a specified window, making it non-interactable.
+        /// </summary>
+        /// <param name="window">The <see cref="Window"/> to apply click-through behavior to.</param>
+        void EnableClickThrough(Window window);
+
+        /// <summary>
+        /// Updates the position and size of an overlay window to match the target window,
+        /// using pre-transformed coordinates provided by the caller.
+        /// </summary>
+        /// <param name="overlayWindow">The <see cref="Window"/> overlay that should be repositioned.</param>
+        /// <param name="transformedRect">The transformed <see cref="Rect"/> representing the new position and size.</param>
+        void UpdateOverlayPosition(Window overlayWindow, Rect transformedRect);
     }
 }

--- a/src/WinReform/WinReform.Domain/Windows/Window.cs
+++ b/src/WinReform/WinReform.Domain/Windows/Window.cs
@@ -47,6 +47,29 @@ namespace WinReform.Domain.Windows
         private string _description = string.Empty;
 
         /// <summary>
+        /// Gets or sets the title of the window as displayed on the title bar.
+        /// </summary>
+        public string WindowTitle
+        {
+            get => _windowTitle;
+            set => SetProperty(ref _windowTitle, value);
+        }
+
+        private string _windowTitle = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the name of the process that owns the window.
+        /// </summary>
+        public string ProcessName
+        {
+            get => _processName;
+            set => SetProperty(ref _processName, value);
+        }
+
+        private string _processName = string.Empty;
+
+
+        /// <summary>
         /// Gets or Sets the icon of the application that owns the window
         /// </summary>
         public Bitmap? Icon
@@ -91,18 +114,21 @@ namespace WinReform.Domain.Windows
             {
                 return 0;
             }
+
             return -1;
         }
 
         /// <summary>
-        /// Comapares the current <see cref="Window"/> to a given <see cref="Window"/>
+        /// Compares the current <see cref="Window"/> with another <see cref="Window"/>.
         /// </summary>
-        /// <param name="other"><see cref="Window"/> to compare to the current instance</param>
-        /// <returns>Returns <see langword="true"/> if the current istance is equal to the given <see cref="Window"/>, otherwise returns <see langword="false"/></returns>
+        /// <param name="other">The <see cref="Window"/> instance to compare to the current instance.</param>
+        /// <returns>Returns <see langword="true"/> if the current instance is equal to the given <see cref="Window"/>; otherwise, returns <see langword="false"/>.</returns>
         public bool Equals([AllowNull] Window other)
             => other?.Id == Id
             && other?.WindowHandle == WindowHandle
             && other?.Description == Description
+            && other?.WindowTitle == WindowTitle
+            && other?.ProcessName == ProcessName
             && other?.Dimensions == Dimensions;
 
         /// <summary>
@@ -110,9 +136,7 @@ namespace WinReform.Domain.Windows
         /// </summary>
         /// <param name="obj"><see cref="object"/> to compare to the current instance</param>
         /// <returns>Returns <see langword="true"/> if the current istance is equal to the given <see cref="object"/>, otherwise returns <see langword="false"/></returns>
-        public override bool Equals(object? obj)
-            => obj is Window window
-            && Equals(window);
+        public override bool Equals(object? obj) => obj is Window window && Equals(window);
 
         /// <summary>
         /// Gets the hashCode of the <see cref="Window"/>

--- a/src/WinReform/WinReform.Domain/Windows/WindowService.cs
+++ b/src/WinReform/WinReform.Domain/Windows/WindowService.cs
@@ -56,7 +56,11 @@ namespace WinReform.Domain.Windows
                     }
 
                     var description = string.Empty;
+                    var windowTitle = _winApiService.GetWindowTitle(process.MainWindowHandle);
+                    var processName = process.ProcessName;
+                    var processId = process.Id;
                     Bitmap? iconBitmap = null;
+
                     if (CanAccessProcess(process))
                     {
                         description = process.MainModule?.FileVersionInfo?.FileDescription ?? string.Empty;
@@ -68,11 +72,19 @@ namespace WinReform.Domain.Windows
                         }
                     }
 
+                    // Fallbacks: If description is empty, use process name or window title
+                    if (string.IsNullOrWhiteSpace(description))
+                    {
+                        description = !string.IsNullOrWhiteSpace(windowTitle) ? windowTitle : processName;
+                    }
+
                     windows.Add(new Window()
                     {
-                        Id = process.Id,
+                        Id = processId,
                         WindowHandle = process.MainWindowHandle,
                         Description = description,
+                        WindowTitle = windowTitle,
+                        ProcessName = processName,
                         Icon = iconBitmap,
                         Dimensions = dimensions
                     });

--- a/src/WinReform/WinReform.Domain/Windows/WindowService.cs
+++ b/src/WinReform/WinReform.Domain/Windows/WindowService.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
+using System.Drawing.Drawing2D;
 using WinReform.Domain.Process;
 using WinReform.Domain.WinApi;
 using WinReform.Domain.WinApi.Types;
@@ -12,6 +13,12 @@ namespace WinReform.Domain.Windows
     /// </summary>
     public class WindowService : IWindowService
     {
+        /// <summary>
+        /// Stores a mapping between window handles and their corresponding event hook handles.
+        /// This ensures that each tracked window has a registered movement event hook,
+        /// </summary>
+        private readonly Dictionary<IntPtr, IntPtr> _windowHooks = [];
+
         /// <summary>
         /// <see cref="IWinApiService"/> used to manage existing windows
         /// </summary>
@@ -128,6 +135,24 @@ namespace WinReform.Domain.Windows
         }
 
         /// <inheritdoc/>
+        public Window UpdateWindow(Window window)
+        {
+            ArgumentNullException.ThrowIfNull(window);
+
+            var updatedRect = _winApiService.GetVisibleWindowRect(window.WindowHandle);
+            return new Window
+            {
+                Id = window.Id,
+                WindowHandle = window.WindowHandle,
+                Description = window.Description,
+                WindowTitle = window.WindowTitle,
+                ProcessName = window.ProcessName,
+                Icon = window.Icon,
+                Dimensions = updatedRect
+            };
+        }
+
+        /// <inheritdoc/>
         public void ResizeWindow(Window window, Rect resolution)
         {
             var newWidth = resolution.Right == 0 ? window.Dimensions.Right : resolution.Right;
@@ -165,6 +190,50 @@ namespace WinReform.Domain.Windows
         public void RedrawWindow(Window window)
         {
             _winApiService.RedrawMenuBar(window.WindowHandle);
+        }
+
+        /// <inheritdoc/>
+        public void HookWindowMoveEvent(Window targetWindow, Action callback)
+        {
+            ArgumentNullException.ThrowIfNull(targetWindow);
+
+            if (_windowHooks.ContainsKey(targetWindow.WindowHandle))
+            {
+                return; // Prevent duplicate hooks
+            }
+
+            var hook = _winApiService.RegisterWindowMoveHook(targetWindow.WindowHandle, callback);
+            _windowHooks[targetWindow.WindowHandle] = hook;
+        }
+
+        /// <inheritdoc/>
+        public void UnhookWindowMoveEvent(Window targetWindow)
+        {
+            ArgumentNullException.ThrowIfNull(targetWindow);
+
+            if (_windowHooks.TryGetValue(targetWindow.WindowHandle, out var hookHandle))
+            {
+                _winApiService.UnregisterWindowMoveHook(hookHandle);
+                _windowHooks.Remove(targetWindow.WindowHandle);
+            }
+        }
+
+        /// <inheritdoc/>
+        public void EnableClickThrough(Window window)
+        {
+            ArgumentNullException.ThrowIfNull(window);
+
+            var extendedStyle = _winApiService.GetWindowLongPtr(window.WindowHandle, GwlType.ExStyle).ToInt32();
+            _winApiService.SetWindowLongPtr(window.WindowHandle, GwlType.ExStyle, new IntPtr(extendedStyle | (int)ExWsStyleType.Transparent | (int)ExWsStyleType.Layered));
+        }
+
+        /// <inheritdoc/>
+        public void UpdateOverlayPosition(Window overlayWindow, Rect transformedRect)
+        {
+            ArgumentNullException.ThrowIfNull(overlayWindow);
+
+            // Use pre-transformed coordinates to update overlay position
+            _winApiService.SetWindowPos(overlayWindow.WindowHandle, transformedRect, SwpType.NoActive | SwpType.NoZOrder);
         }
     }
 }

--- a/src/WinReform/WinReform/ActiveWindows/ActiveWindowsViewModel.cs
+++ b/src/WinReform/WinReform/ActiveWindows/ActiveWindowsViewModel.cs
@@ -7,10 +7,12 @@ using System.Windows.Threading;
 using WinReform.Domain.Infrastructure.Messanger;
 using WinReform.Domain.Infrastructure.Messenger;
 using WinReform.Domain.Settings;
+using WinReform.Domain.WinApi;
 using WinReform.Domain.Windows;
 using WinReform.Infrastructure.Common.Command;
 using WinReform.Infrastructure.Common.ViewModel;
 using WinReform.Infrastructure.Extensions;
+using WinReform.Overlay;
 
 namespace WinReform.ActiveWindows
 {
@@ -28,6 +30,16 @@ namespace WinReform.ActiveWindows
         /// State that defines if processes with 0x0 size windows should be displayed in the Active Windows list
         /// </summary>
         private bool _showZeroSizeWindows;
+
+        /// <summary>
+        /// Indicates whether or not to display a overlays on top of selected windows
+        /// </summary>
+        private bool _highlightSelectedWindows;
+
+        /// <summary>
+        /// Stores active overlay windows mapped to their corresponding window handles
+        /// </summary>
+        private readonly Dictionary<IntPtr, OverlayWindow> _overlayWindows = [];
 
         ///<inheritdoc/>
         public bool DisplayLocation
@@ -152,6 +164,13 @@ namespace WinReform.ActiveWindows
         {
             _autoRefreshTimer.Stop();
             _autoRefreshTimer.Tick -= OnAutoRefreshEvent;
+
+            // Remove all window overlays
+            foreach (var overlay in _overlayWindows.Values)
+            {
+                overlay.Close();
+            }
+            _overlayWindows.Clear();
         }
 
         /// <summary>
@@ -193,6 +212,7 @@ namespace WinReform.ActiveWindows
                 DisplayLocation = settings.CurrentSetting.DisplayActiveWindowLocation;
                 _autoRefreshActiveWindows = settings.CurrentSetting.AutoRefreshActiveWindows;
                 _showZeroSizeWindows = settings.CurrentSetting.ShowZeroSizeWindows;
+                _highlightSelectedWindows = settings.CurrentSetting.HighlightSelectedWindows;
             }
         }
 
@@ -203,7 +223,54 @@ namespace WinReform.ActiveWindows
         /// <param name="e"></param>
         private void SelectedActiveWindowsChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
+            // Remove highlight from deselected windows
+            foreach (var removedItem in e.OldItems?.Cast<Domain.Windows.Window>() ?? [])
+            {
+                RemoveHighlight(removedItem);
+            }
+
+            if (_highlightSelectedWindows)
+            {
+                // Add highlight to newly selected windows
+                foreach (var addedItem in e.NewItems?.Cast<Domain.Windows.Window>() ?? [])
+                {
+                    HighlightWindow(addedItem);
+                }
+            }
+
+            // Publish the selection change event
             _eventAggregator.GetEvent<ActiveWindowsSelectionChangedEvent>().Publish(SelectedActiveWindows.ToList());
+        }
+
+        /// <summary>
+        /// Creates and displays an overlay window for the specified window if it is not already highlighted.
+        /// This ensures each window can have only one overlay at a time.
+        /// </summary>
+        /// <param name="window">The <see cref="Domain.Windows.Window"/> to highlight.</param>
+        private void HighlightWindow(Domain.Windows.Window window)
+        {
+            if (_overlayWindows.ContainsKey(window.WindowHandle))
+            {
+                return;
+            }
+
+            var overlay = new OverlayWindow(window, _windowService);
+            _overlayWindows[window.WindowHandle] = overlay;
+            overlay.Show();
+        }
+
+        /// <summary>
+        /// Removes the overlay window associated with the specified window.
+        /// Ensures the overlay is properly closed and removed from tracking.
+        /// </summary>
+        /// <param name="window">The <see cref="Domain.Windows.Window"/> whose highlight should be removed.</param>
+        private void RemoveHighlight(Domain.Windows.Window window)
+        {
+            if (_overlayWindows.TryGetValue(window.WindowHandle, out var overlay))
+            {
+                overlay.Close();
+                _overlayWindows.Remove(window.WindowHandle);
+            }
         }
     }
 }

--- a/src/WinReform/WinReform/Overlay/OverlayWindow.xaml
+++ b/src/WinReform/WinReform/Overlay/OverlayWindow.xaml
@@ -1,0 +1,22 @@
+﻿<mah:MetroWindow x:Class="WinReform.Overlay.OverlayWindow"
+                 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                 xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
+                 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                 mc:Ignorable="d"
+                 WindowStyle="None"
+                 AllowsTransparency="True"
+                 Background="Transparent"
+                 Topmost="True"
+                 ShowInTaskbar="False"
+                 ResizeMode="NoResize"
+                 IsHitTestVisible="False"
+                 ShowTitleBar="False"
+                 ShowCloseButton="False"
+                 ShowMinButton="False"
+                 ShowMaxRestoreButton="False">
+
+    <!-- The border for highlighting -->
+    <Border BorderBrush="Red" BorderThickness="3" CornerRadius="5" />
+</mah:MetroWindow>

--- a/src/WinReform/WinReform/Overlay/OverlayWindow.xaml.cs
+++ b/src/WinReform/WinReform/Overlay/OverlayWindow.xaml.cs
@@ -1,0 +1,109 @@
+﻿using System.Windows;
+using System.Windows.Interop;
+using System.Windows.Media;
+using MahApps.Metro.Controls;
+using WinReform.Domain.Windows;
+
+namespace WinReform.Overlay
+{
+    /// <summary>
+    /// Represents an overlay window that visually highlights a selected window.
+    /// </summary>
+    public partial class OverlayWindow : MetroWindow
+    {
+        /// <summary>
+        /// The target window that this overlay is tracking.
+        /// </summary>
+        private Domain.Windows.Window _targetWindow;
+
+        /// <summary>
+        /// The overlay window that visually represents the target window.
+        /// </summary>
+        private Domain.Windows.Window _overlayWindow;
+
+        /// <summary>
+        /// <see cref="IWindowService"/> used to get all active windows
+        /// </summary>
+        private readonly IWindowService _windowService;
+
+        public OverlayWindow(Domain.Windows.Window targetWindow, IWindowService windowService)
+        {
+            InitializeComponent();
+
+            _targetWindow = targetWindow ?? throw new ArgumentNullException(nameof(targetWindow));
+            _windowService = windowService ?? throw new ArgumentNullException(nameof(windowService));
+
+            Background = Brushes.Transparent;
+            BorderBrush = Brushes.Red;
+            BorderThickness = new Thickness(3);
+            AllowsTransparency = true;
+            Topmost = true;
+
+            Loaded += OverlayWindow_Loaded;
+        }
+
+        /// <summary>
+        /// Handles the <see cref="Loaded"/> event to initialize the overlay window.
+        /// </summary>
+        private void OverlayWindow_Loaded(object sender, RoutedEventArgs e)
+        {
+            _overlayWindow = new Domain.Windows.Window
+            {
+                Description = $"{_targetWindow.Description} Overlay",
+                WindowTitle = $"{_targetWindow.WindowTitle} Overlay",
+                Dimensions = _targetWindow.Dimensions,
+                WindowHandle = new WindowInteropHelper(this).Handle
+            };
+
+            HookWindowMoveEvent();
+            EnableClickThrough();
+            UpdatePosition();
+        }
+
+        /// <summary>
+        /// Enables click-through behavior for the overlay, making it non-interactable.
+        /// </summary>
+        private void EnableClickThrough()
+        {
+            _windowService.EnableClickThrough(_overlayWindow);
+        }
+
+        /// <summary>
+        /// Updates the overlay's position to match the target window.
+        /// This method applies DPI scaling to ensure proper alignment.
+        /// </summary>
+        private void UpdatePosition()
+        {
+            // Retrieve the latest position and size of the target window
+            _targetWindow = _windowService.UpdateWindow(_targetWindow);
+
+            // Convert from WinAPI screen coordinates to WPF logical coordinates
+            var transform = PresentationSource.FromVisual(this)?.CompositionTarget?.TransformFromDevice ?? Matrix.Identity;
+            var topLeft = transform.Transform(new Point(_targetWindow.Dimensions.Left, _targetWindow.Dimensions.Top));
+            var bottomRight = transform.Transform(new Point(_targetWindow.Dimensions.Right, _targetWindow.Dimensions.Bottom));
+
+            var transformedRect = new Domain.WinApi.Rect((int)topLeft.X, (int)topLeft.Y, (int)(bottomRight.X - topLeft.X), (int)(bottomRight.Y - topLeft.Y));
+
+            _windowService.UpdateOverlayPosition(_overlayWindow, transformedRect);
+        }
+
+        /// <summary>
+        /// Registers a hook to track movement events of the target window.
+        /// When the window moves, the overlay position is updated accordingly.
+        /// </summary>
+        private void HookWindowMoveEvent()
+        {
+            _windowService.HookWindowMoveEvent(_targetWindow, () => UpdatePosition());
+        }
+
+        /// <summary>
+        /// Handles cleanup when the overlay window is closed.
+        /// This ensures that the movement tracking hook is unregistered.
+        /// </summary>
+        protected override void OnClosed(EventArgs e)
+        {
+            base.OnClosed(e);
+            _windowService.UnhookWindowMoveEvent(_targetWindow);
+        }
+    }
+}

--- a/src/WinReform/WinReform/Settings/ApplicationSettingsDesignModel.cs
+++ b/src/WinReform/WinReform/Settings/ApplicationSettingsDesignModel.cs
@@ -20,6 +20,9 @@
         ///<inheritdoc/>
         public bool ShowZeroSizeWindows { get; set; }
 
+        ///<inheritdoc/>
+        public bool HighlightSelectedWindows { get; set; }
+
         /// <summary>
         /// Create a new instance of the <see cref="ApplicationSettingsDesignModel"/>
         /// </summary>
@@ -30,6 +33,7 @@
             MinimizeOnClose = true;
             AutoRefreshActiveWindows = false;
             ShowZeroSizeWindows = false;
+            HighlightSelectedWindows = true;
         }
     }
 }

--- a/src/WinReform/WinReform/Settings/ApplicationSettingsView.xaml
+++ b/src/WinReform/WinReform/Settings/ApplicationSettingsView.xaml
@@ -27,6 +27,7 @@
                 <RowDefinition Height="32" />
                 <RowDefinition Height="32" />
                 <RowDefinition Height="32" />
+                <RowDefinition Height="32" />
             </Grid.RowDefinitions>
 
             <TextBlock Grid.Row="0"
@@ -61,17 +62,29 @@
                   ToolTip="If enabled the PID column in Active Windows will be repalced with the Location information"
                   IsChecked="{Binding DisplayActiveWindowLocation}" />
 
-            <TextBlock Grid.Row="4"
+            <TextBlock Grid.Row="3"
                    Grid.Column="0"
                    VerticalAlignment="Center"
                    Margin="8"
                    Text="Show 0x0 Size Windows" />
-            <CheckBox Grid.Row="4"
+            <CheckBox Grid.Row="3"
                   Grid.Column="1"
                   VerticalAlignment="Center"
                   Margin="5"
                   ToolTip="If enabled, windows with a size of 0x0 will be displayed in the Active Windows list"
                   IsChecked="{Binding ShowZeroSizeWindows}" />
+
+            <TextBlock Grid.Row="4"
+                   Grid.Column="0"
+                   VerticalAlignment="Center"
+                   Margin="8"
+                   Text="Highlight Selected Windows" />
+            <CheckBox Grid.Row="4"
+                  Grid.Column="1"
+                  VerticalAlignment="Center"
+                  Margin="5"
+                  ToolTip="If enabled, a red border will be rendered on top of each selected window"
+                  IsChecked="{Binding HighlightSelectedWindows}" />
         </Grid>
 
         <!-- Behaviour-->

--- a/src/WinReform/WinReform/Settings/ApplicationSettingsViewModel.cs
+++ b/src/WinReform/WinReform/Settings/ApplicationSettingsViewModel.cs
@@ -79,6 +79,20 @@ namespace WinReform.Settings
 
         private bool _showZeroSizeWindows;
 
+        ///<inheritdoc/>
+        public bool HighlightSelectedWindows
+        {
+            get => _highlightSelectedWindows;
+            set
+            {
+                SetProperty(ref _highlightSelectedWindows, value);
+                _settings.CurrentSetting.HighlightSelectedWindows = value;
+                SaveSettings();
+            }
+        }
+
+        private bool _highlightSelectedWindows;
+
         /// <summary>
         /// <see cref="ISetting{TSetting}"/> containing the <see cref="ApplicationSettings"/>
         /// </summary>
@@ -98,6 +112,7 @@ namespace WinReform.Settings
             MinimizeOnClose = _settings.CurrentSetting.MinimizeOnClose;
             AutoRefreshActiveWindows = _settings.CurrentSetting.AutoRefreshActiveWindows;
             ShowZeroSizeWindows = _settings.CurrentSetting.ShowZeroSizeWindows;
+            HighlightSelectedWindows = _settings.CurrentSetting.HighlightSelectedWindows;
         }
 
         /// <summary>

--- a/src/WinReform/WinReform/Settings/IApplicationSettingsViewModel.cs
+++ b/src/WinReform/WinReform/Settings/IApplicationSettingsViewModel.cs
@@ -29,5 +29,10 @@
         /// Gets or Sets the state that defines if processes with 0x0 size windows should be displayed
         /// </summary>
         bool ShowZeroSizeWindows { get; set; }
+
+        /// <summary>
+        /// Gets or Sets the state that defines if an overlay should be rendered on top of each selected window
+        /// </summary>
+        bool HighlightSelectedWindows { get; set; }
     }
 }


### PR DESCRIPTION
## What does the pull request do?
Adds a new setting that when enabled adds a red overlay on the selected windows


## What is the current behavior?
Currently there is no way to identify the selected window


## What is the updated/expected behavior with this PR?
Windows in the list should be more likely to have a name, as the description now has the window title, or process name as fallback.

If the overlay setting is enabled, each selected window in the list should have a red border drawn that follows the window.
If the setting is off, no overlay should be drawn

## How was the solution implemented (if it's not obvious)?
A new overlay window was added, a listener for window moves allows us to update the overlay location as the window moves around


## Checklist

- [ ] Added unit tests (if possible)?
- [x] Added XML documentation to any related classes?

## Breaking changes
N/A

## Fixed issues
Fixes #49 

